### PR TITLE
fix creating extension with global option appendonly=true

### DIFF
--- a/control/ddl/diskquota--1.0--2.0.sql
+++ b/control/ddl/diskquota--1.0--2.0.sql
@@ -9,7 +9,7 @@ CREATE TABLE diskquota.target (
 	primaryOid oid,
 	tablespaceOid oid, -- REFERENCES pg_tablespace.oid,
 	PRIMARY KEY (primaryOid, tablespaceOid, quotatype)
-);
+) WITH (appendonly=false);
 -- TODO ALTER TABLE diskquota.target SET DEPENDS ON EXTENSION diskquota;
 
 ALTER TABLE diskquota.table_size ADD COLUMN segid smallint DEFAULT -1; -- segid = coordinator means table size in cluster level

--- a/control/ddl/diskquota--1.0.3--2.0.sql
+++ b/control/ddl/diskquota--1.0.3--2.0.sql
@@ -9,7 +9,7 @@ CREATE TABLE diskquota.target (
 	primaryOid oid,
 	tablespaceOid oid, -- REFERENCES pg_tablespace.oid,
 	PRIMARY KEY (primaryOid, tablespaceOid, quotatype)
-);
+) WITH (appendonly=false);
 -- TODO ALTER TABLE diskquota.target SET DEPENDS ON EXTENSION diskquota;
 
 ALTER TABLE diskquota.table_size ADD COLUMN segid smallint DEFAULT -1; -- segid = coordinator means table size in cluster level

--- a/control/ddl/diskquota--1.0.sql
+++ b/control/ddl/diskquota--1.0.sql
@@ -9,18 +9,18 @@ CREATE TABLE diskquota.quota_config(
     quotatype int,
     quotalimitMB int8,
     PRIMARY KEY(targetOid, quotatype)
-);
+) WITH (appendonly=false);
 
 CREATE TABLE diskquota.table_size(
     tableid oid,
     size bigint,
     PRIMARY KEY(tableid)
-);
+) WITH (appendonly=false);
 
 CREATE TABLE diskquota.state(
     state int,
     PRIMARY KEY(state)
-);
+) WITH (appendonly=false);
 
 -- only diskquota.quota_config is dump-able, other table can be generate on fly
 SELECT pg_catalog.pg_extension_config_dump('diskquota.quota_config', '');

--- a/control/ddl/diskquota--2.0.sql
+++ b/control/ddl/diskquota--2.0.sql
@@ -11,7 +11,7 @@ CREATE TABLE diskquota.quota_config(
 	quotalimitMB int8,
 	segratio float4 DEFAULT 0,
 	PRIMARY KEY(targetOid, quotatype)
-) DISTRIBUTED BY (targetOid, quotatype);
+) WITH (appendonly=false) DISTRIBUTED BY (targetOid, quotatype);
 
 CREATE TABLE diskquota.target (
 	rowId serial,
@@ -19,19 +19,19 @@ CREATE TABLE diskquota.target (
 	primaryOid oid,
 	tablespaceOid oid, --REFERENCES pg_tablespace.oid,
 	PRIMARY KEY (primaryOid, tablespaceOid, quotatype)
-);
+) WITH (appendonly=false);
 
 CREATE TABLE diskquota.table_size(
 	tableid oid,
 	size bigint,
 	segid smallint,
 	PRIMARY KEY(tableid, segid)
-) DISTRIBUTED BY (tableid, segid);
+) WITH (appendonly=false) DISTRIBUTED BY (tableid, segid);
 
 CREATE TABLE diskquota.state(
 	state int,
 	PRIMARY KEY(state)
-) DISTRIBUTED BY (state);
+) WITH (appendonly=false) DISTRIBUTED BY (state);
 
 -- diskquota.quota_config AND diskquota.target is dump-able, other table can be generate on fly
 SELECT pg_catalog.pg_extension_config_dump('diskquota.quota_config', '');

--- a/control/ddl/diskquota--2.1.sql
+++ b/control/ddl/diskquota--2.1.sql
@@ -11,7 +11,7 @@ CREATE TABLE diskquota.quota_config(
 	quotalimitMB int8,
 	segratio float4 DEFAULT 0,
 	PRIMARY KEY(targetOid, quotatype)
-) DISTRIBUTED BY (targetOid, quotatype);
+) WITH (appendonly=false) DISTRIBUTED BY (targetOid, quotatype);
 
 CREATE TABLE diskquota.target (
 	rowId serial,
@@ -19,19 +19,19 @@ CREATE TABLE diskquota.target (
 	primaryOid oid,
 	tablespaceOid oid, --REFERENCES pg_tablespace.oid,
 	PRIMARY KEY (primaryOid, tablespaceOid, quotatype)
-);
+) WITH (appendonly=false);
 
 CREATE TABLE diskquota.table_size(
 	tableid oid,
 	size bigint,
 	segid smallint,
 	PRIMARY KEY(tableid, segid)
-) DISTRIBUTED BY (tableid, segid);
+) WITH (appendonly=false) DISTRIBUTED BY (tableid, segid);
 
 CREATE TABLE diskquota.state(
 	state int,
 	PRIMARY KEY(state)
-) DISTRIBUTED BY (state);
+) WITH (appendonly=false) DISTRIBUTED BY (state);
 
 -- diskquota.quota_config AND diskquota.target is dump-able, other table can be generate on fly
 SELECT pg_catalog.pg_extension_config_dump('diskquota.quota_config', '');

--- a/control/ddl/diskquota--2.2.sql
+++ b/control/ddl/diskquota--2.2.sql
@@ -11,7 +11,7 @@ CREATE TABLE diskquota.quota_config(
 	quotalimitMB int8,
 	segratio float4 DEFAULT 0,
 	PRIMARY KEY(targetOid, quotatype)
-) DISTRIBUTED BY (targetOid, quotatype);
+) WITH (appendonly=false) DISTRIBUTED BY (targetOid, quotatype);
 
 CREATE TABLE diskquota.target (
 	rowId serial,
@@ -19,19 +19,19 @@ CREATE TABLE diskquota.target (
 	primaryOid oid,
 	tablespaceOid oid, --REFERENCES pg_tablespace.oid,
 	PRIMARY KEY (primaryOid, tablespaceOid, quotatype)
-);
+) WITH (appendonly=false);
 
 CREATE TABLE diskquota.table_size(
 	tableid oid,
 	size bigint,
 	segid smallint,
 	PRIMARY KEY(tableid, segid)
-) DISTRIBUTED BY (tableid, segid);
+) WITH (appendonly=false) DISTRIBUTED BY (tableid, segid);
 
 CREATE TABLE diskquota.state(
 	state int,
 	PRIMARY KEY(state)
-) DISTRIBUTED BY (state);
+) WITH (appendonly=false) DISTRIBUTED BY (state);
 
 -- diskquota.quota_config AND diskquota.target is dump-able, other table can be generate on fly
 SELECT pg_catalog.pg_extension_config_dump('diskquota.quota_config', '');

--- a/tests/isolation2/expected/test_create_extension.out
+++ b/tests/isolation2/expected/test_create_extension.out
@@ -1,3 +1,16 @@
+-- check that diskquota ignores global flag appendonly=true
+
+SET gp_default_storage_options='appendonly=true';
+SET
+
+CREATE EXTENSION diskquota;
+CREATE
+DROP EXTENSION diskquota;
+DROP
+
+SET gp_default_storage_options='appendonly=false';
+SET
+
 CREATE EXTENSION diskquota;
 CREATE
 

--- a/tests/isolation2/sql/test_create_extension.sql
+++ b/tests/isolation2/sql/test_create_extension.sql
@@ -1,3 +1,12 @@
+-- check that diskquota ignores global flag appendonly=true
+
+SET gp_default_storage_options='appendonly=true';
+
+CREATE EXTENSION diskquota;
+DROP EXTENSION diskquota;
+
+SET gp_default_storage_options='appendonly=false';
+
 CREATE EXTENSION diskquota;
 
 SELECT diskquota.init_table_size_table();

--- a/tests/regress/expected/test_create_extension.out
+++ b/tests/regress/expected/test_create_extension.out
@@ -1,3 +1,8 @@
+-- check that diskquota ignores global flag appendonly=true
+SET gp_default_storage_options='appendonly=true';
+CREATE EXTENSION diskquota;
+DROP EXTENSION diskquota;
+SET gp_default_storage_options='appendonly=false';
 CREATE EXTENSION diskquota;
 SELECT diskquota.init_table_size_table();
  init_table_size_table 

--- a/tests/regress/sql/test_create_extension.sql
+++ b/tests/regress/sql/test_create_extension.sql
@@ -1,3 +1,12 @@
+-- check that diskquota ignores global flag appendonly=true
+
+SET gp_default_storage_options='appendonly=true';
+
+CREATE EXTENSION diskquota;
+DROP EXTENSION diskquota;
+
+SET gp_default_storage_options='appendonly=false';
+
 CREATE EXTENSION diskquota;
 
 SELECT diskquota.init_table_size_table();


### PR DESCRIPTION
All tables use primary keys. Unique index tables are created for primary keys. Unique index tables can not be created for table with appendonly=true. appendonly=false has been added for each table with primary key.

## Steps to reproduce.
1) build diskquota extension
2) append it to shared_preload_libraries
3) create diskquota database
4) restart cluster
5) execute in the postgres (on any oyher) database:
```
set gp_default_storage_options='appendonly=true';
create extension diskquota;
```
## Result
```
ERROR:  append-only tables do not support unique indexes
```