### PR TITLE
ADBDEV-4618 Free tuple after use

### DIFF
--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -2058,6 +2058,8 @@ refresh_rejectmap(PG_FUNCTION_ARGS)
 					break;
 				}
 			}
+
+			heap_freetuple(tuple);
 		}
 		else
 		{
@@ -2119,10 +2121,6 @@ refresh_rejectmap(PG_FUNCTION_ARGS)
 				}
 			}
 			LWLockRelease(diskquota_locks.relation_cache_lock);
-		}
-		if (HeapTupleIsValid(tuple))
-		{
-			heap_freetuple(tuple);
 		}
 	}
 

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -2047,6 +2047,8 @@ refresh_rejectmap(PG_FUNCTION_ARGS)
 								memcpy(&blocked_filenode_entry->auxblockinfo, &keyitem, sizeof(RejectMapEntry));
 								blocked_filenode_entry->segexceeded = rejectmapentry->segexceeded;
 							}
+
+							heap_freetuple(curr_tuple);
 						}
 					}
 					/*
@@ -2117,6 +2119,10 @@ refresh_rejectmap(PG_FUNCTION_ARGS)
 				}
 			}
 			LWLockRelease(diskquota_locks.relation_cache_lock);
+		}
+		if (HeapTupleIsValid(tuple))
+		{
+			heap_freetuple(tuple);
 		}
 	}
 


### PR DESCRIPTION
refresh_rejectmap looks for a tuple using SearchSysCacheCopy1 which retrieves
a copy of the tuple allocating memory for it. However, refresh_rejectmap didn't
free these tuple copies after use. If lots of oids were passed, diskquota could
work incorrectly because of huge memory leak. This patch frees these tuples and
prevents memory leaks.