### PR TITLE
ADBDEV-6442: Refactor diskquota local_table_stats_map

### DIFF
--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -1207,7 +1207,7 @@ pull_active_table_size_from_seg(HTAB *local_table_stats_map, char *active_oid_ar
 			else
 			{
 				/* sum table size from all the segments */
-				entry->tablesize[segId + 1] = entry->tablesize[segId + 1] + tableSize;
+				entry->tablesize[segId + 1] += tableSize;
 			}
 		}
 	}

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -1185,7 +1185,7 @@ pull_active_table_size_from_seg(HTAB *local_table_stats_map, char *active_oid_ar
 			if (PQnfields(pgresult) == 3)
 			{
 				/* get the segid, tablesize for each table */
-				segId = atoi(PQgetvalue(pgresult, j, 2));
+				segId                       = atoi(PQgetvalue(pgresult, j, 2));
 				entry->tablesize[segId + 1] = tableSize;
 			}
 

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -375,11 +375,11 @@ gp_fetch_active_tables(bool is_init)
 
 	memset(&ctl, 0, sizeof(ctl));
 	ctl.keysize   = sizeof(Oid);
-	ctl.entrysize = offsetof(ActiveTableEntryCombined, tablesize) + (SEGCOUNT + 1) * sizeof(Size);
+	ctl.entrysize = sizeof(ActiveTableEntryCombined) + SEGCOUNT * sizeof(Size);
 	ctl.hcxt      = CurrentMemoryContext;
 
 	local_table_stats_map = diskquota_hash_create("local active table map with relfilenode info", 1024, &ctl,
-	                                              HASH_ELEM | HASH_CONTEXT, DISKQUOTA_TAG_HASH);
+	                                              HASH_ELEM | HASH_CONTEXT, DISKQUOTA_OID_HASH);
 
 	if (is_init)
 	{

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -1190,10 +1190,7 @@ pull_active_table_size_from_seg(HTAB *local_table_stats_map, char *active_oid_ar
 			}
 
 			/* tablesize for index 0 is the sum of tablesize of master and all segments */
-			if (found)
-				entry->tablesize[0] += tableSize;
-			else
-				entry->tablesize[0] = tableSize;
+			entry->tablesize[0] = (found ? entry->tablesize[0] : 0) + tableSize;
 		}
 	}
 	cdbdisp_clearCdbPgResults(&cdb_pgresults);

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -1189,11 +1189,11 @@ pull_active_table_size_from_seg(HTAB *local_table_stats_map, char *active_oid_ar
 				entry->tablesize[segId + 1] = tableSize;
 			}
 
-			/* when segid is -1, the tablesize is the sum of tablesize of master and all segments */
-			if (!found) entry->tablesize[0] = 0;
-
-			/* sum table size from all the segments */
-			entry->tablesize[0] += tableSize;
+			/* tablesize for index 0 is the sum of tablesize of master and all segments */
+			if (found)
+				entry->tablesize[0] += tableSize;
+			else
+				entry->tablesize[0] = tableSize;
 		}
 	}
 	cdbdisp_clearCdbPgResults(&cdb_pgresults);

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -375,7 +375,7 @@ gp_fetch_active_tables(bool is_init)
 
 	memset(&ctl, 0, sizeof(ctl));
 	ctl.keysize   = sizeof(Oid);
-	ctl.entrysize = sizeof(ActiveTableEntryCombined) + SEGCOUNT * sizeof(Size);
+	ctl.entrysize = offsetof(ActiveTableEntryCombined, tablesize) + (SEGCOUNT + 1) * sizeof(Size);
 	ctl.hcxt      = CurrentMemoryContext;
 
 	local_table_stats_map = diskquota_hash_create("local active table map with relfilenode info", 1024, &ctl,

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -1191,7 +1191,6 @@ pull_active_table_size_from_seg(HTAB *local_table_stats_map, char *active_oid_ar
 
 			/* when segid is -1, the tablesize is the sum of tablesize of master and all segments */
 			segId = -1;
-			// entry = (ActiveTableEntryCombined *)hash_search(local_table_stats_map, &reloid, HASH_ENTER, &found);
 
 			if (!found)
 			{

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -1179,29 +1179,23 @@ pull_active_table_size_from_seg(HTAB *local_table_stats_map, char *active_oid_ar
 		{
 			reloid    = atooid(PQgetvalue(pgresult, j, 0));
 			tableSize = (Size)atoll(PQgetvalue(pgresult, j, 1));
+			entry     = (ActiveTableEntryCombined *)hash_search(local_table_stats_map, &reloid, HASH_ENTER, &found);
+
 			/* for diskquota extension version is 1.0, pgresult doesn't contain segid */
 			if (PQnfields(pgresult) == 3)
 			{
 				/* get the segid, tablesize for each table */
 				segId = atoi(PQgetvalue(pgresult, j, 2));
-				entry = (ActiveTableEntryCombined *)hash_search(local_table_stats_map, &reloid, HASH_ENTER, &found);
-
-				if (!found)
-				{
-					/* receive table size info from the first segment */
-					entry->reloid = reloid;
-				}
 				entry->tablesize[segId + 1] = tableSize;
 			}
 
 			/* when segid is -1, the tablesize is the sum of tablesize of master and all segments */
 			segId = -1;
-			entry = (ActiveTableEntryCombined *)hash_search(local_table_stats_map, &reloid, HASH_ENTER, &found);
+			// entry = (ActiveTableEntryCombined *)hash_search(local_table_stats_map, &reloid, HASH_ENTER, &found);
 
 			if (!found)
 			{
 				/* receive table size info from the first segment */
-				entry->reloid               = reloid;
 				entry->tablesize[segId + 1] = tableSize;
 			}
 			else

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -1190,9 +1190,7 @@ pull_active_table_size_from_seg(HTAB *local_table_stats_map, char *active_oid_ar
 			}
 
 			/* when segid is -1, the tablesize is the sum of tablesize of master and all segments */
-
-			if (!found)
-				entry->tablesize[0] = 0;
+			if (!found) entry->tablesize[0] = 0;
 
 			/* sum table size from all the segments */
 			entry->tablesize[0] += tableSize;

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -1190,18 +1190,12 @@ pull_active_table_size_from_seg(HTAB *local_table_stats_map, char *active_oid_ar
 			}
 
 			/* when segid is -1, the tablesize is the sum of tablesize of master and all segments */
-			segId = -1;
 
 			if (!found)
-			{
-				/* receive table size info from the first segment */
-				entry->tablesize[segId + 1] = tableSize;
-			}
-			else
-			{
-				/* sum table size from all the segments */
-				entry->tablesize[segId + 1] += tableSize;
-			}
+				entry->tablesize[0] = 0;
+
+			/* sum table size from all the segments */
+			entry->tablesize[0] += tableSize;
 		}
 	}
 	cdbdisp_clearCdbPgResults(&cdb_pgresults);

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -946,13 +946,13 @@ get_active_tables_oid(void)
 static void
 load_table_size(HTAB *local_table_stats_map)
 {
-	TupleDesc                  tupdesc;
-	int                        i;
-	bool                       found;
-	ActiveTableEntryCombined  *quota_entry;
-	SPIPlanPtr                 plan;
-	Portal                     portal;
-	char                      *sql = "select tableid, size, segid from diskquota.table_size";
+	TupleDesc                 tupdesc;
+	int                       i;
+	bool                      found;
+	ActiveTableEntryCombined *quota_entry;
+	SPIPlanPtr                plan;
+	Portal                    portal;
+	char                     *sql = "select tableid, size, segid from diskquota.table_size";
 
 	if ((plan = SPI_prepare(sql, 0, NULL)) == NULL)
 		ereport(ERROR, (errmsg("[diskquota] SPI_prepare(\"%s\") failed", sql)));
@@ -1015,10 +1015,10 @@ load_table_size(HTAB *local_table_stats_map)
 			size = DatumGetInt64(dat);
 			dat  = SPI_getbinval(tup, tupdesc, 3, &isnull);
 			if (isnull) continue;
-			segid      = DatumGetInt16(dat);
+			segid = DatumGetInt16(dat);
 
 			quota_entry = (ActiveTableEntryCombined *)hash_search(local_table_stats_map, &reloid, HASH_ENTER, &found);
-			quota_entry->reloid    = reloid;
+			quota_entry->reloid               = reloid;
 			quota_entry->tablesize[segid + 1] = size;
 		}
 		SPI_freetuptable(SPI_tuptable);
@@ -1160,11 +1160,11 @@ pull_active_table_size_from_seg(HTAB *local_table_stats_map, char *active_oid_ar
 	/* sum table size from each segment into local_table_stats_map */
 	for (i = 0; i < cdb_pgresults.numResults; i++)
 	{
-		Size                       tableSize;
-		bool                       found;
-		Oid                        reloid;
-		int                        segId;
-		ActiveTableEntryCombined  *entry;
+		Size                      tableSize;
+		bool                      found;
+		Oid                       reloid;
+		int                       segId;
+		ActiveTableEntryCombined *entry;
 
 		PGresult *pgresult = cdb_pgresults.pg_results[i];
 
@@ -1177,14 +1177,14 @@ pull_active_table_size_from_seg(HTAB *local_table_stats_map, char *active_oid_ar
 
 		for (j = 0; j < PQntuples(pgresult); j++)
 		{
-			reloid     = atooid(PQgetvalue(pgresult, j, 0));
-			tableSize  = (Size)atoll(PQgetvalue(pgresult, j, 1));
+			reloid    = atooid(PQgetvalue(pgresult, j, 0));
+			tableSize = (Size)atoll(PQgetvalue(pgresult, j, 1));
 			/* for diskquota extension version is 1.0, pgresult doesn't contain segid */
 			if (PQnfields(pgresult) == 3)
 			{
 				/* get the segid, tablesize for each table */
-				segId     = atoi(PQgetvalue(pgresult, j, 2));
-				entry     = (ActiveTableEntryCombined *)hash_search(local_table_stats_map, &reloid, HASH_ENTER, &found);
+				segId = atoi(PQgetvalue(pgresult, j, 2));
+				entry = (ActiveTableEntryCombined *)hash_search(local_table_stats_map, &reloid, HASH_ENTER, &found);
 
 				if (!found)
 				{
@@ -1196,12 +1196,12 @@ pull_active_table_size_from_seg(HTAB *local_table_stats_map, char *active_oid_ar
 
 			/* when segid is -1, the tablesize is the sum of tablesize of master and all segments */
 			segId = -1;
-			entry     = (ActiveTableEntryCombined *)hash_search(local_table_stats_map, &reloid, HASH_ENTER, &found);
+			entry = (ActiveTableEntryCombined *)hash_search(local_table_stats_map, &reloid, HASH_ENTER, &found);
 
 			if (!found)
 			{
 				/* receive table size info from the first segment */
-				entry->reloid    = reloid;
+				entry->reloid               = reloid;
 				entry->tablesize[segId + 1] = tableSize;
 			}
 			else

--- a/src/gp_activetable.h
+++ b/src/gp_activetable.h
@@ -40,7 +40,11 @@ typedef struct DiskQuotaActiveTableEntry
 typedef struct ActiveTableEntryCombined
 {
 	Oid  reloid;
-	Size tablesize[1]; /* variable length array */
+	/*
+	 Variable length array: index 0 is used for the coordinator,
+	 the remaining SEGCOUNT indexes are for segments.
+	 */
+	Size tablesize[1];
 } ActiveTableEntryCombined;
 
 extern HTAB *gp_fetch_active_tables(bool force);

--- a/src/gp_activetable.h
+++ b/src/gp_activetable.h
@@ -39,7 +39,7 @@ typedef struct DiskQuotaActiveTableEntry
 
 typedef struct ActiveTableEntryCombined
 {
-	Oid  reloid;
+	Oid reloid;
 	/*
 	 Variable length array: index 0 is used for the coordinator,
 	 the remaining SEGCOUNT indexes are for segments.

--- a/src/gp_activetable.h
+++ b/src/gp_activetable.h
@@ -40,7 +40,7 @@ typedef struct DiskQuotaActiveTableEntry
 typedef struct ActiveTableEntryCombined
 {
 	Oid  reloid;
-	Size tablesize[];
+	Size tablesize[1]; /* variable length array */
 } ActiveTableEntryCombined;
 
 extern HTAB *gp_fetch_active_tables(bool force);

--- a/src/gp_activetable.h
+++ b/src/gp_activetable.h
@@ -37,6 +37,12 @@ typedef struct DiskQuotaActiveTableEntry
 	Size tablesize;
 } DiskQuotaActiveTableEntry;
 
+typedef struct ActiveTableEntryCombined
+{
+	Oid  reloid;
+	Size tablesize[];
+} ActiveTableEntryCombined;
+
 extern HTAB *gp_fetch_active_tables(bool force);
 extern void  init_active_table_hook(void);
 extern void  init_shm_worker_active_tables(void);

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -1052,7 +1052,8 @@ calculate_table_disk_usage(bool is_init, HTAB *local_active_table_stat_map)
 					/* pretend process as utility mode, and append the table size on master */
 					Gp_role = GP_ROLE_UTILITY;
 
-					active_table_entry->tablesize[cur_segid + 1] += calculate_table_size(relOid);
+					/* when cur_segid is -1, the tablesize is the sum of tablesize of master and all segments */
+					active_table_entry->tablesize[0] += calculate_table_size(relOid);
 
 					Gp_role = GP_ROLE_DISPATCH;
 				}

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -912,18 +912,18 @@ merge_uncommitted_table_to_oidlist(List *oidlist)
 static void
 calculate_table_disk_usage(bool is_init, HTAB *local_active_table_stat_map)
 {
-	bool                       table_size_map_found;
-	bool                       active_tbl_found;
-	int64                      updated_total_size;
-	TableSizeEntry            *tsentry = NULL;
-	Oid                        relOid;
-	HASH_SEQ_STATUS            iter;
-	ActiveTableEntryCombined  *active_table_entry;
-	TableSizeEntryKey          key;
-	List                      *oidlist;
-	ListCell                  *l;
-	int                        delete_entries_num = 0;
-	StringInfoData             delete_statement;
+	bool                      table_size_map_found;
+	bool                      active_tbl_found;
+	int64                     updated_total_size;
+	TableSizeEntry           *tsentry = NULL;
+	Oid                       relOid;
+	HASH_SEQ_STATUS           iter;
+	ActiveTableEntryCombined *active_table_entry;
+	TableSizeEntryKey         key;
+	List                     *oidlist;
+	ListCell                 *l;
+	int                       delete_entries_num = 0;
+	StringInfoData            delete_statement;
 
 	initStringInfo(&delete_statement);
 
@@ -1041,8 +1041,8 @@ calculate_table_disk_usage(bool is_init, HTAB *local_active_table_stat_map)
 
 			/* mark tsentry is_exist */
 			if (tsentry) set_table_size_entry_flag(tsentry, TABLE_EXIST);
-			active_table_entry      = (ActiveTableEntryCombined *)hash_search(
-			             local_active_table_stat_map, &relOid, HASH_FIND, &active_tbl_found);
+			active_table_entry = (ActiveTableEntryCombined *)hash_search(local_active_table_stat_map, &relOid,
+			                                                             HASH_FIND, &active_tbl_found);
 
 			/* skip to recalculate the tables which are not in active list */
 			if (active_tbl_found)
@@ -1057,7 +1057,8 @@ calculate_table_disk_usage(bool is_init, HTAB *local_active_table_stat_map)
 					Gp_role = GP_ROLE_DISPATCH;
 				}
 				/* firstly calculate the updated total size of a table */
-				updated_total_size = active_table_entry->tablesize[cur_segid + 1] - TableSizeEntryGetSize(tsentry, cur_segid);
+				updated_total_size =
+				        active_table_entry->tablesize[cur_segid + 1] - TableSizeEntryGetSize(tsentry, cur_segid);
 
 				/* update the table_size entry */
 				TableSizeEntrySetSize(tsentry, cur_segid, active_table_entry->tablesize[cur_segid + 1]);
@@ -1342,14 +1343,14 @@ flush_local_reject_map(void)
 static void
 dispatch_rejectmap(HTAB *local_active_table_stat_map)
 {
-	HASH_SEQ_STATUS            hash_seq;
-	GlobalRejectMapEntry      *rejectmap_entry;
-	ActiveTableEntryCombined  *active_table_entry;
-	int                        num_entries, count = 0;
-	CdbPgResults               cdb_pgresults = {NULL, 0};
-	StringInfoData             rows;
-	StringInfoData             active_oids;
-	StringInfoData             sql;
+	HASH_SEQ_STATUS           hash_seq;
+	GlobalRejectMapEntry     *rejectmap_entry;
+	ActiveTableEntryCombined *active_table_entry;
+	int                       num_entries, count = 0;
+	CdbPgResults              cdb_pgresults = {NULL, 0};
+	StringInfoData            rows;
+	StringInfoData            active_oids;
+	StringInfoData            sql;
 
 	initStringInfo(&rows);
 	initStringInfo(&active_oids);

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -918,9 +918,8 @@ calculate_table_disk_usage(bool is_init, HTAB *local_active_table_stat_map)
 	TableSizeEntry            *tsentry = NULL;
 	Oid                        relOid;
 	HASH_SEQ_STATUS            iter;
-	DiskQuotaActiveTableEntry *active_table_entry;
+	ActiveTableEntryCombined  *active_table_entry;
 	TableSizeEntryKey          key;
-	TableEntryKey              active_table_key;
 	List                      *oidlist;
 	ListCell                  *l;
 	int                        delete_entries_num = 0;
@@ -1042,10 +1041,8 @@ calculate_table_disk_usage(bool is_init, HTAB *local_active_table_stat_map)
 
 			/* mark tsentry is_exist */
 			if (tsentry) set_table_size_entry_flag(tsentry, TABLE_EXIST);
-			active_table_key.reloid = relOid;
-			active_table_key.segid  = cur_segid;
-			active_table_entry      = (DiskQuotaActiveTableEntry *)hash_search(
-			             local_active_table_stat_map, &active_table_key, HASH_FIND, &active_tbl_found);
+			active_table_entry      = (ActiveTableEntryCombined *)hash_search(
+			             local_active_table_stat_map, &relOid, HASH_FIND, &active_tbl_found);
 
 			/* skip to recalculate the tables which are not in active list */
 			if (active_tbl_found)
@@ -1055,15 +1052,15 @@ calculate_table_disk_usage(bool is_init, HTAB *local_active_table_stat_map)
 					/* pretend process as utility mode, and append the table size on master */
 					Gp_role = GP_ROLE_UTILITY;
 
-					active_table_entry->tablesize += calculate_table_size(relOid);
+					active_table_entry->tablesize[cur_segid + 1] += calculate_table_size(relOid);
 
 					Gp_role = GP_ROLE_DISPATCH;
 				}
 				/* firstly calculate the updated total size of a table */
-				updated_total_size = active_table_entry->tablesize - TableSizeEntryGetSize(tsentry, cur_segid);
+				updated_total_size = active_table_entry->tablesize[cur_segid + 1] - TableSizeEntryGetSize(tsentry, cur_segid);
 
 				/* update the table_size entry */
-				TableSizeEntrySetSize(tsentry, cur_segid, active_table_entry->tablesize);
+				TableSizeEntrySetSize(tsentry, cur_segid, active_table_entry->tablesize[cur_segid + 1]);
 				TableSizeEntrySetFlushFlag(tsentry, cur_segid);
 
 				/* update the disk usage, there may be entries in the map whose keys are InvlidOid as the tsentry does
@@ -1347,7 +1344,7 @@ dispatch_rejectmap(HTAB *local_active_table_stat_map)
 {
 	HASH_SEQ_STATUS            hash_seq;
 	GlobalRejectMapEntry      *rejectmap_entry;
-	DiskQuotaActiveTableEntry *active_table_entry;
+	ActiveTableEntryCombined  *active_table_entry;
 	int                        num_entries, count = 0;
 	CdbPgResults               cdb_pgresults = {NULL, 0};
 	StringInfoData             rows;


### PR DESCRIPTION
Refactor diskquota local_table_stats_map

During initialization, diskquota used a non-optimal structure for the local
hashmap local_table_stats_map. In a hashmap, there is quite a significant
overhead for each entry. Therefore, a large number of small entries led to
increased RAM consumption during cluster startup. Change the specified
structure, making the table oid as the key, and an array of sizes by segments
as the value. This significantly reduces the amount of memory consumed, because
now there will be SEGCOUNT times fewer records. Also fix a small bug with
duplicate oid tables in the active_oids string array in the dispatch_rejectmap
function.

---
Tests are not provided, but you can estimate the hashmap size using the `hash_estimate_size` function, for example, like this:
```diff
diff --git a/src/gp_activetable.c b/src/gp_activetable.c
index 0888c4d..5b7654d 100644
--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -954,6 +954,9 @@ load_table_size(HTAB *local_table_stats_map)
 	Portal                    portal;
 	char                     *sql = "select tableid, size, segid from diskquota.table_size";
 
+	elog(WARNING, "DiskQuotaActiveTableEntry = %li", hash_estimate_size(1000*1000*1000, sizeof(DiskQuotaActiveTableEntry)));
+	elog(WARNING, "ActiveTableEntryCombined = %li", hash_estimate_size(1000*1000, offsetof(ActiveTableEntryCombined, tablesize) + (1000 + 1) * sizeof(Size)));
+
 	if ((plan = SPI_prepare(sql, 0, NULL)) == NULL)
 		ereport(ERROR, (errmsg("[diskquota] SPI_prepare(\"%s\") failed", sql)));
 	if ((portal = SPI_cursor_open(NULL, plan, NULL, NULL, true)) == NULL)
```
that gives
```csv
2024-10-10 14:15:23.186300 +05,,,p684028,th1126361536,,,,0,con9,,seg-1,,,,sx1,"WARNING","01000","DiskQuotaActiveTableEntry = 40623489136",,,,,,,0,,"gp_activetable.c",957,
2024-10-10 14:15:23.186315 +05,,,p684028,th1126361536,,,,0,con9,,seg-1,,,,sx1,"WARNING","01000","ActiveTableEntryCombined = 8040421488",,,,,,,0,,"gp_activetable.c",958,
```
That is, the memory consumption for 1,000,000 tables on a 1000-segment cluster dropped from 38 gigabytes to 7.5 gigabytes.

---
It is easier to view the changes with the "Hide whitespace" option enabled.