### PR TITLE
ADBDEV-6577: Use short-lived SPI contexts

### DIFF
--- a/src/diskquota.c
+++ b/src/diskquota.c
@@ -1048,8 +1048,8 @@ init_database_list(void)
 	 */
 	StartTransactionCommand();
 	PushActiveSnapshot(GetTransactionSnapshot());
-	SPI_connect_wrapper(&state);
 
+	SPI_connect_wrapper(&state);
 	ret = SPI_execute("select dbid from diskquota_namespace.database_list;", true, 0);
 	if (ret != SPI_OK_SELECT)
 	{

--- a/src/diskquota.c
+++ b/src/diskquota.c
@@ -964,7 +964,6 @@ create_monitor_db_table(void)
 	bool        pushed_active_snap = false;
 	bool        ret                = true;
 
-	StartTransactionCommand();
 	/*
 	 * Create function diskquota.diskquota_fetch_table_stat in launcher
 	 * We need this function to distribute dbid to segments when creating
@@ -982,6 +981,8 @@ create_monitor_db_table(void)
 	      "CREATE FUNCTION " LAUNCHER_SCHEMA ".diskquota_fetch_table_stat(int4, oid[]) RETURNS setof " LAUNCHER_SCHEMA
 	      ".diskquota_active_table_type AS '$libdir/" DISKQUOTA_BINARY_NAME
 	      ".so', 'diskquota_fetch_table_stat' LANGUAGE C VOLATILE;";
+
+	StartTransactionCommand();
 
 	/*
 	 * Cache Errors during SPI functions, for example a segment may be down

--- a/src/diskquota.c
+++ b/src/diskquota.c
@@ -1005,7 +1005,7 @@ create_monitor_db_table(void)
 		HOLD_INTERRUPTS();
 		EmitErrorReport();
 		FlushErrorState();
-		state |= is_abort;
+		state |= IS_ABORT;
 		debug_query_string = NULL;
 		/* Now we can allow interrupts again */
 		RESUME_INTERRUPTS();
@@ -1189,7 +1189,7 @@ do_process_extension_ddl_message(MessageResult *code, ExtensionDDLMessage local_
 		HOLD_INTERRUPTS();
 		EmitErrorReport();
 		FlushErrorState();
-		state |= is_abort;
+		state |= IS_ABORT;
 		num_db = old_num_db;
 		RESUME_INTERRUPTS();
 	}
@@ -1198,7 +1198,7 @@ do_process_extension_ddl_message(MessageResult *code, ExtensionDDLMessage local_
 	SPI_finish_wrapper(state);
 
 	/* update something in memory after transaction committed */
-	if (!(state & is_abort))
+	if (!(state & IS_ABORT))
 	{
 		PG_TRY();
 		{
@@ -1233,7 +1233,7 @@ do_process_extension_ddl_message(MessageResult *code, ExtensionDDLMessage local_
 			HOLD_INTERRUPTS();
 			EmitErrorReport();
 			FlushErrorState();
-			state |= is_abort;
+			state |= IS_ABORT;
 			RESUME_INTERRUPTS();
 		}
 		PG_END_TRY();

--- a/src/diskquota.c
+++ b/src/diskquota.c
@@ -194,7 +194,7 @@ is_altering_extension_to_default_version(char *version)
 			if (strcmp(version, default_version) == 0) ret = true;
 		}
 	}
-	SPI_finish_if_connected(connected);
+	SPI_finish_if(connected);
 	return ret;
 }
 
@@ -1017,7 +1017,7 @@ create_monitor_db_table(void)
 		RESUME_INTERRUPTS();
 	}
 	PG_END_TRY();
-	SPI_finish_if_connected(connected);
+	SPI_finish_if(connected);
 	if (pushed_active_snap) PopActiveSnapshot();
 	if (ret)
 		CommitTransactionCommand();
@@ -1107,7 +1107,7 @@ init_database_list(void)
 		}
 	}
 	num_db = num;
-	SPI_finish_if_connected(connected);
+	SPI_finish_if(connected);
 	/* As update_monitor_db_mpp needs to execute sql, so can not put in the loop above */
 	for (int i = 0; i < diskquota_max_monitored_databases; i++)
 	{
@@ -1378,7 +1378,7 @@ add_dbid_to_database_list(Oid dbid)
 	}
 
 ret:
-	SPI_finish_if_connected(connected);
+	SPI_finish_if(connected);
 }
 
 /*
@@ -1407,7 +1407,7 @@ del_dbid_from_database_list(Oid dbid)
 		                       strerror(saved_errno), ret)));
 	}
 
-	SPI_finish_if_connected(connected);
+	SPI_finish_if(connected);
 }
 
 /*
@@ -1629,11 +1629,11 @@ diskquota_status_schema_version()
 
 	StrNCpy(ret_version, version, sizeof(ret_version) - 1);
 
-	SPI_finish_if_connected(connected);
+	SPI_finish_if(connected);
 	return ret_version;
 
 fail:
-	SPI_finish_if_connected(connected);
+	SPI_finish_if(connected);
 	return "";
 }
 

--- a/src/diskquota.c
+++ b/src/diskquota.c
@@ -1363,9 +1363,7 @@ add_dbid_to_database_list(Oid dbid)
 		ereport(WARNING, (errmsg("[diskquota launcher] database id %d is already actived, "
 		                         "skip database_list update",
 		                         dbid)));
-
-		SPI_finish_wrapper(connected);
-		return;
+		goto ret;
 	}
 
 	ret = SPI_execute_with_args("insert into diskquota_namespace.database_list values($1)", 1, argt, argv, NULL, false,
@@ -1379,6 +1377,7 @@ add_dbid_to_database_list(Oid dbid)
 		                       ret, strerror(saved_errno))));
 	}
 
+ret:
 	SPI_finish_wrapper(connected);
 }
 

--- a/src/diskquota.c
+++ b/src/diskquota.c
@@ -986,7 +986,7 @@ create_monitor_db_table(void)
 	 */
 	PG_TRY();
 	{
-		state = SPI_connect_wrapper();
+		SPI_connect_wrapper(&state);
 
 		/* debug_query_string need to be set for SPI_execute utility functions. */
 		debug_query_string = sql;
@@ -1027,8 +1027,9 @@ init_database_list(void)
 	int       num = 0;
 	int       ret;
 	int       i;
-	int       state = SPI_connect_wrapper();
+	int       state = 0;
 
+	SPI_connect_wrapper(&state);
 	/*
 	 * Don't catch errors in start_workers_from_dblist. Since this is the
 	 * startup worker for diskquota launcher. If error happens, we just let
@@ -1162,7 +1163,7 @@ do_process_extension_ddl_message(MessageResult *code, ExtensionDDLMessage local_
 	 */
 	PG_TRY();
 	{
-		state = SPI_connect_wrapper();
+		SPI_connect_wrapper(&state);
 
 		switch (local_extension_ddl_message.cmd)
 		{
@@ -1204,7 +1205,7 @@ do_process_extension_ddl_message(MessageResult *code, ExtensionDDLMessage local_
 		{
 			/* update_monitor_db_mpp runs sql to distribute dbid to segments */
 			Oid dbid = local_extension_ddl_message.dbid;
-			state    = SPI_connect_wrapper();
+			SPI_connect_wrapper(&state);
 			switch (local_extension_ddl_message.cmd)
 			{
 				case CMD_CREATE_EXTENSION:

--- a/src/diskquota.c
+++ b/src/diskquota.c
@@ -177,7 +177,7 @@ is_altering_extension_to_default_version(char *version)
 {
 	int  spi_ret;
 	bool ret       = false;
-	bool connected = SPI_connect_wrapper();
+	bool connected = SPI_connect_if_not_yet();
 	spi_ret = SPI_execute("select default_version from pg_available_extensions where name ='diskquota'", true, 0);
 	if (spi_ret != SPI_OK_SELECT)
 		elog(ERROR, "[diskquota] failed to select diskquota default version during diskquota update.");
@@ -194,7 +194,7 @@ is_altering_extension_to_default_version(char *version)
 			if (strcmp(version, default_version) == 0) ret = true;
 		}
 	}
-	SPI_finish_wrapper(connected);
+	SPI_finish_if_connected(connected);
 	return ret;
 }
 
@@ -990,7 +990,7 @@ create_monitor_db_table(void)
 	 */
 	PG_TRY();
 	{
-		connected = SPI_connect_wrapper();
+		connected = SPI_connect_if_not_yet();
 		PushActiveSnapshot(GetTransactionSnapshot());
 		pushed_active_snap = true;
 
@@ -1017,7 +1017,7 @@ create_monitor_db_table(void)
 		RESUME_INTERRUPTS();
 	}
 	PG_END_TRY();
-	SPI_finish_wrapper(connected);
+	SPI_finish_if_connected(connected);
 	if (pushed_active_snap) PopActiveSnapshot();
 	if (ret)
 		CommitTransactionCommand();
@@ -1047,7 +1047,7 @@ init_database_list(void)
 	StartTransactionCommand();
 	PushActiveSnapshot(GetTransactionSnapshot());
 
-	bool connected = SPI_connect_wrapper();
+	bool connected = SPI_connect_if_not_yet();
 	ret            = SPI_execute("select dbid from diskquota_namespace.database_list;", true, 0);
 	if (ret != SPI_OK_SELECT)
 	{
@@ -1107,7 +1107,7 @@ init_database_list(void)
 		}
 	}
 	num_db = num;
-	SPI_finish_wrapper(connected);
+	SPI_finish_if_connected(connected);
 	/* As update_monitor_db_mpp needs to execute sql, so can not put in the loop above */
 	for (int i = 0; i < diskquota_max_monitored_databases; i++)
 	{
@@ -1345,7 +1345,7 @@ add_dbid_to_database_list(Oid dbid)
 
 	Oid   argt[1]   = {OIDOID};
 	Datum argv[1]   = {ObjectIdGetDatum(dbid)};
-	bool  connected = SPI_connect_wrapper();
+	bool  connected = SPI_connect_if_not_yet();
 
 	ret = SPI_execute_with_args("select * from diskquota_namespace.database_list where dbid = $1", 1, argt, argv, NULL,
 	                            true, 0);
@@ -1378,7 +1378,7 @@ add_dbid_to_database_list(Oid dbid)
 	}
 
 ret:
-	SPI_finish_wrapper(connected);
+	SPI_finish_if_connected(connected);
 }
 
 /*
@@ -1389,7 +1389,7 @@ static void
 del_dbid_from_database_list(Oid dbid)
 {
 	int  ret;
-	bool connected = SPI_connect_wrapper();
+	bool connected = SPI_connect_if_not_yet();
 
 	/* errors will be cached in outer function */
 	ret = SPI_execute_with_args("delete from diskquota_namespace.database_list where dbid = $1", 1,
@@ -1407,7 +1407,7 @@ del_dbid_from_database_list(Oid dbid)
 		                       strerror(saved_errno), ret)));
 	}
 
-	SPI_finish_wrapper(connected);
+	SPI_finish_if_connected(connected);
 }
 
 /*
@@ -1601,7 +1601,7 @@ static const char *
 diskquota_status_schema_version()
 {
 	static char ret_version[64];
-	bool        connected = SPI_connect_wrapper();
+	bool        connected = SPI_connect_if_not_yet();
 	int         ret       = SPI_execute("select extversion from pg_extension where extname = 'diskquota'", true, 0);
 
 	if (ret != SPI_OK_SELECT || SPI_processed != 1)
@@ -1629,11 +1629,11 @@ diskquota_status_schema_version()
 
 	StrNCpy(ret_version, version, sizeof(ret_version) - 1);
 
-	SPI_finish_wrapper(connected);
+	SPI_finish_if_connected(connected);
 	return ret_version;
 
 fail:
-	SPI_finish_wrapper(connected);
+	SPI_finish_if_connected(connected);
 	return "";
 }
 

--- a/src/diskquota.c
+++ b/src/diskquota.c
@@ -176,8 +176,8 @@ static bool
 is_altering_extension_to_default_version(char *version)
 {
 	int  spi_ret;
-	bool ret       = false;
-	bool connected = SPI_connect_if_not_yet();
+	bool ret                        = false;
+	bool connected_in_this_function = SPI_connect_if_not_yet();
 	spi_ret = SPI_execute("select default_version from pg_available_extensions where name ='diskquota'", true, 0);
 	if (spi_ret != SPI_OK_SELECT)
 		elog(ERROR, "[diskquota] failed to select diskquota default version during diskquota update.");
@@ -194,7 +194,7 @@ is_altering_extension_to_default_version(char *version)
 			if (strcmp(version, default_version) == 0) ret = true;
 		}
 	}
-	SPI_finish_if(connected);
+	SPI_finish_if(connected_in_this_function);
 	return ret;
 }
 
@@ -959,9 +959,9 @@ static void
 create_monitor_db_table(void)
 {
 	const char *sql;
-	bool        connected          = false;
-	bool        pushed_active_snap = false;
-	bool        ret                = true;
+	bool        connected_in_this_function = false;
+	bool        pushed_active_snap         = false;
+	bool        ret                        = true;
 
 	/*
 	 * Create function diskquota.diskquota_fetch_table_stat in launcher
@@ -990,7 +990,7 @@ create_monitor_db_table(void)
 	 */
 	PG_TRY();
 	{
-		connected = SPI_connect_if_not_yet();
+		connected_in_this_function = SPI_connect_if_not_yet();
 		PushActiveSnapshot(GetTransactionSnapshot());
 		pushed_active_snap = true;
 
@@ -1017,7 +1017,7 @@ create_monitor_db_table(void)
 		RESUME_INTERRUPTS();
 	}
 	PG_END_TRY();
-	SPI_finish_if(connected);
+	SPI_finish_if(connected_in_this_function);
 	if (pushed_active_snap) PopActiveSnapshot();
 	if (ret)
 		CommitTransactionCommand();
@@ -1047,8 +1047,8 @@ init_database_list(void)
 	StartTransactionCommand();
 	PushActiveSnapshot(GetTransactionSnapshot());
 
-	bool connected = SPI_connect_if_not_yet();
-	ret            = SPI_execute("select dbid from diskquota_namespace.database_list;", true, 0);
+	bool connected_in_this_function = SPI_connect_if_not_yet();
+	ret                             = SPI_execute("select dbid from diskquota_namespace.database_list;", true, 0);
 	if (ret != SPI_OK_SELECT)
 	{
 		int saved_errno = errno;
@@ -1107,7 +1107,7 @@ init_database_list(void)
 		}
 	}
 	num_db = num;
-	SPI_finish_if(connected);
+	SPI_finish_if(connected_in_this_function);
 	/* As update_monitor_db_mpp needs to execute sql, so can not put in the loop above */
 	for (int i = 0; i < diskquota_max_monitored_databases; i++)
 	{
@@ -1343,9 +1343,9 @@ add_dbid_to_database_list(Oid dbid)
 {
 	int ret;
 
-	Oid   argt[1]   = {OIDOID};
-	Datum argv[1]   = {ObjectIdGetDatum(dbid)};
-	bool  connected = SPI_connect_if_not_yet();
+	Oid   argt[1]                    = {OIDOID};
+	Datum argv[1]                    = {ObjectIdGetDatum(dbid)};
+	bool  connected_in_this_function = SPI_connect_if_not_yet();
 
 	ret = SPI_execute_with_args("select * from diskquota_namespace.database_list where dbid = $1", 1, argt, argv, NULL,
 	                            true, 0);
@@ -1378,7 +1378,7 @@ add_dbid_to_database_list(Oid dbid)
 	}
 
 ret:
-	SPI_finish_if(connected);
+	SPI_finish_if(connected_in_this_function);
 }
 
 /*
@@ -1389,7 +1389,7 @@ static void
 del_dbid_from_database_list(Oid dbid)
 {
 	int  ret;
-	bool connected = SPI_connect_if_not_yet();
+	bool connected_in_this_function = SPI_connect_if_not_yet();
 
 	/* errors will be cached in outer function */
 	ret = SPI_execute_with_args("delete from diskquota_namespace.database_list where dbid = $1", 1,
@@ -1407,7 +1407,7 @@ del_dbid_from_database_list(Oid dbid)
 		                       strerror(saved_errno), ret)));
 	}
 
-	SPI_finish_if(connected);
+	SPI_finish_if(connected_in_this_function);
 }
 
 /*
@@ -1601,8 +1601,8 @@ static const char *
 diskquota_status_schema_version()
 {
 	static char ret_version[64];
-	bool        connected = SPI_connect_if_not_yet();
-	int         ret       = SPI_execute("select extversion from pg_extension where extname = 'diskquota'", true, 0);
+	bool        connected_in_this_function = SPI_connect_if_not_yet();
+	int         ret = SPI_execute("select extversion from pg_extension where extname = 'diskquota'", true, 0);
 
 	if (ret != SPI_OK_SELECT || SPI_processed != 1)
 	{
@@ -1629,11 +1629,11 @@ diskquota_status_schema_version()
 
 	StrNCpy(ret_version, version, sizeof(ret_version) - 1);
 
-	SPI_finish_if(connected);
+	SPI_finish_if(connected_in_this_function);
 	return ret_version;
 
 fail:
-	SPI_finish_if(connected);
+	SPI_finish_if(connected_in_this_function);
 	return "";
 }
 

--- a/src/diskquota.c
+++ b/src/diskquota.c
@@ -1205,7 +1205,6 @@ do_process_extension_ddl_message(MessageResult *code, ExtensionDDLMessage local_
 		CommitTransactionCommand();
 	else
 		AbortCurrentTransaction();
-
 	/* update something in memory after transaction committed */
 	if (ret)
 	{

--- a/src/diskquota.c
+++ b/src/diskquota.c
@@ -1388,18 +1388,17 @@ ret:
 static void
 del_dbid_from_database_list(Oid dbid)
 {
-	int  ret;
 	bool connected_in_this_function = SPI_connect_if_not_yet();
 
 	/* errors will be cached in outer function */
-	ret = SPI_execute_with_args("delete from diskquota_namespace.database_list where dbid = $1", 1,
-	                            (Oid[]){
-	                                    OIDOID,
-	                            },
-	                            (Datum[]){
-	                                    ObjectIdGetDatum(dbid),
-	                            },
-	                            NULL, false, 0);
+	int ret = SPI_execute_with_args("delete from diskquota_namespace.database_list where dbid = $1", 1,
+	                                (Oid[]){
+	                                        OIDOID,
+	                                },
+	                                (Datum[]){
+	                                        ObjectIdGetDatum(dbid),
+	                                },
+	                                NULL, false, 0);
 	if (ret != SPI_OK_DELETE)
 	{
 		int saved_errno = errno;

--- a/src/diskquota.c
+++ b/src/diskquota.c
@@ -1152,7 +1152,7 @@ process_extension_ddl_message()
 static void
 do_process_extension_ddl_message(MessageResult *code, ExtensionDDLMessage local_extension_ddl_message)
 {
-	int state = 0;
+	int state      = 0;
 	int old_num_db = num_db;
 
 	/*

--- a/src/diskquota.c
+++ b/src/diskquota.c
@@ -1343,10 +1343,9 @@ add_dbid_to_database_list(Oid dbid)
 {
 	int ret;
 
-	Oid   argt[1] = {OIDOID};
-	Datum argv[1] = {ObjectIdGetDatum(dbid)};
-
-	bool connected = SPI_connect_wrapper();
+	Oid   argt[1]   = {OIDOID};
+	Datum argv[1]   = {ObjectIdGetDatum(dbid)};
+	bool  connected = SPI_connect_wrapper();
 
 	ret = SPI_execute_with_args("select * from diskquota_namespace.database_list where dbid = $1", 1, argt, argv, NULL,
 	                            true, 0);

--- a/src/diskquota.c
+++ b/src/diskquota.c
@@ -1227,7 +1227,10 @@ do_process_extension_ddl_message(MessageResult *code, ExtensionDDLMessage local_
 		PG_TRY();
 		{
 			/* update_monitor_db_mpp runs sql to distribute dbid to segments */
-			Oid dbid = local_extension_ddl_message.dbid;
+			StartTransactionCommand();
+			PushActiveSnapshot(GetTransactionSnapshot());
+			pushed_active_snap = true;
+			Oid dbid           = local_extension_ddl_message.dbid;
 			switch (local_extension_ddl_message.cmd)
 			{
 				case CMD_CREATE_EXTENSION:
@@ -1249,6 +1252,8 @@ do_process_extension_ddl_message(MessageResult *code, ExtensionDDLMessage local_
 					                     local_extension_ddl_message.cmd)));
 					break;
 			}
+			if (pushed_active_snap) PopActiveSnapshot();
+			CommitTransactionCommand();
 		}
 		PG_CATCH();
 		{

--- a/src/diskquota.c
+++ b/src/diskquota.c
@@ -958,7 +958,7 @@ disk_quota_launcher_main(Datum main_arg)
 static void
 create_monitor_db_table(void)
 {
-	int         state;
+	int         state = 0;
 	const char *sql;
 
 	/*
@@ -1152,7 +1152,7 @@ process_extension_ddl_message()
 static void
 do_process_extension_ddl_message(MessageResult *code, ExtensionDDLMessage local_extension_ddl_message)
 {
-	int state;
+	int state = 0;
 	int old_num_db = num_db;
 
 	/*

--- a/src/diskquota.c
+++ b/src/diskquota.c
@@ -958,7 +958,7 @@ disk_quota_launcher_main(Datum main_arg)
 static void
 create_monitor_db_table(void)
 {
-	SPI_state   state;
+	int         state;
 	const char *sql;
 
 	/*
@@ -986,7 +986,7 @@ create_monitor_db_table(void)
 	 */
 	PG_TRY();
 	{
-		SPI_connect_wrapper(&state);
+		state = SPI_connect_wrapper();
 
 		/* debug_query_string need to be set for SPI_execute utility functions. */
 		debug_query_string = sql;
@@ -1005,13 +1005,13 @@ create_monitor_db_table(void)
 		HOLD_INTERRUPTS();
 		EmitErrorReport();
 		FlushErrorState();
-		state.do_commit    = false;
+		state |= is_abort;
 		debug_query_string = NULL;
 		/* Now we can allow interrupts again */
 		RESUME_INTERRUPTS();
 	}
 	PG_END_TRY();
-	SPI_finish_wrapper(&state);
+	SPI_finish_wrapper(state);
 
 	debug_query_string = NULL;
 }
@@ -1023,18 +1023,17 @@ create_monitor_db_table(void)
 static void
 init_database_list(void)
 {
-	SPI_state state;
 	TupleDesc tupdesc;
 	int       num = 0;
 	int       ret;
 	int       i;
+	int       state = SPI_connect_wrapper();
 
 	/*
 	 * Don't catch errors in start_workers_from_dblist. Since this is the
 	 * startup worker for diskquota launcher. If error happens, we just let
 	 * launcher exits.
 	 */
-	SPI_connect_wrapper(&state);
 
 	ret = SPI_execute("select dbid from diskquota_namespace.database_list;", true, 0);
 	if (ret != SPI_OK_SELECT)
@@ -1104,7 +1103,7 @@ init_database_list(void)
 			update_monitor_db_mpp(dbEntry->dbid, ADD_DB_TO_MONITOR, LAUNCHER_SCHEMA);
 		}
 	}
-	SPI_finish_wrapper(&state);
+	SPI_finish_wrapper(state);
 	/* TODO: clean invalid database */
 	if (num_db > diskquota_max_workers) DiskquotaLauncherShmem->isDynamicWorker = true;
 }
@@ -1153,8 +1152,8 @@ process_extension_ddl_message()
 static void
 do_process_extension_ddl_message(MessageResult *code, ExtensionDDLMessage local_extension_ddl_message)
 {
-	SPI_state state;
-	int       old_num_db = num_db;
+	int state;
+	int old_num_db = num_db;
 
 	/*
 	 * Cache Errors during SPI functions, for example a segment may be down
@@ -1163,7 +1162,7 @@ do_process_extension_ddl_message(MessageResult *code, ExtensionDDLMessage local_
 	 */
 	PG_TRY();
 	{
-		SPI_connect_wrapper(&state);
+		state = SPI_connect_wrapper();
 
 		switch (local_extension_ddl_message.cmd)
 		{
@@ -1190,22 +1189,22 @@ do_process_extension_ddl_message(MessageResult *code, ExtensionDDLMessage local_
 		HOLD_INTERRUPTS();
 		EmitErrorReport();
 		FlushErrorState();
-		state.do_commit = false;
-		num_db          = old_num_db;
+		state |= is_abort;
+		num_db = old_num_db;
 		RESUME_INTERRUPTS();
 	}
 	PG_END_TRY();
 
-	SPI_finish_wrapper(&state);
+	SPI_finish_wrapper(state);
 
 	/* update something in memory after transaction committed */
-	if (state.do_commit)
+	if (!(state & is_abort))
 	{
 		PG_TRY();
 		{
 			/* update_monitor_db_mpp runs sql to distribute dbid to segments */
 			Oid dbid = local_extension_ddl_message.dbid;
-			SPI_connect_wrapper(&state);
+			state    = SPI_connect_wrapper();
 			switch (local_extension_ddl_message.cmd)
 			{
 				case CMD_CREATE_EXTENSION:
@@ -1234,12 +1233,12 @@ do_process_extension_ddl_message(MessageResult *code, ExtensionDDLMessage local_
 			HOLD_INTERRUPTS();
 			EmitErrorReport();
 			FlushErrorState();
-			state.do_commit = false;
+			state |= is_abort;
 			RESUME_INTERRUPTS();
 		}
 		PG_END_TRY();
 
-		SPI_finish_wrapper(&state);
+		SPI_finish_wrapper(state);
 	}
 	DisconnectAndDestroyAllGangs(false);
 }

--- a/src/diskquota.c
+++ b/src/diskquota.c
@@ -1154,9 +1154,9 @@ process_extension_ddl_message()
 static void
 do_process_extension_ddl_message(MessageResult *code, ExtensionDDLMessage local_extension_ddl_message)
 {
+	int  old_num_db         = num_db;
 	bool pushed_active_snap = false;
 	bool ret                = true;
-	int  old_num_db         = num_db;
 
 	/*
 	 * Cache Errors during SPI functions, for example a segment may be down

--- a/src/diskquota.c
+++ b/src/diskquota.c
@@ -986,7 +986,7 @@ create_monitor_db_table(void)
 	 */
 	PG_TRY();
 	{
-		SPI_connect_my(&state);
+		SPI_connect_wrapper(&state);
 
 		/* debug_query_string need to be set for SPI_execute utility functions. */
 		debug_query_string = sql;
@@ -1011,7 +1011,7 @@ create_monitor_db_table(void)
 		RESUME_INTERRUPTS();
 	}
 	PG_END_TRY();
-	SPI_finish_my(&state);
+	SPI_finish_wrapper(&state);
 
 	debug_query_string = NULL;
 }
@@ -1034,7 +1034,7 @@ init_database_list(void)
 	 * startup worker for diskquota launcher. If error happens, we just let
 	 * launcher exits.
 	 */
-	SPI_connect_my(&state);
+	SPI_connect_wrapper(&state);
 
 	ret = SPI_execute("select dbid from diskquota_namespace.database_list;", true, 0);
 	if (ret != SPI_OK_SELECT)
@@ -1104,7 +1104,7 @@ init_database_list(void)
 			update_monitor_db_mpp(dbEntry->dbid, ADD_DB_TO_MONITOR, LAUNCHER_SCHEMA);
 		}
 	}
-	SPI_finish_my(&state);
+	SPI_finish_wrapper(&state);
 	/* TODO: clean invalid database */
 	if (num_db > diskquota_max_workers) DiskquotaLauncherShmem->isDynamicWorker = true;
 }
@@ -1163,7 +1163,7 @@ do_process_extension_ddl_message(MessageResult *code, ExtensionDDLMessage local_
 	 */
 	PG_TRY();
 	{
-		SPI_connect_my(&state);
+		SPI_connect_wrapper(&state);
 
 		switch (local_extension_ddl_message.cmd)
 		{
@@ -1196,7 +1196,7 @@ do_process_extension_ddl_message(MessageResult *code, ExtensionDDLMessage local_
 	}
 	PG_END_TRY();
 
-	SPI_finish_my(&state);
+	SPI_finish_wrapper(&state);
 
 	/* update something in memory after transaction committed */
 	if (state.do_commit)
@@ -1205,7 +1205,7 @@ do_process_extension_ddl_message(MessageResult *code, ExtensionDDLMessage local_
 		{
 			/* update_monitor_db_mpp runs sql to distribute dbid to segments */
 			Oid dbid = local_extension_ddl_message.dbid;
-			SPI_connect_my(&state);
+			SPI_connect_wrapper(&state);
 			switch (local_extension_ddl_message.cmd)
 			{
 				case CMD_CREATE_EXTENSION:
@@ -1239,7 +1239,7 @@ do_process_extension_ddl_message(MessageResult *code, ExtensionDDLMessage local_
 		}
 		PG_END_TRY();
 
-		SPI_finish_my(&state);
+		SPI_finish_wrapper(&state);
 	}
 	DisconnectAndDestroyAllGangs(false);
 }

--- a/src/diskquota.c
+++ b/src/diskquota.c
@@ -1030,12 +1030,12 @@ init_database_list(void)
 	int       i;
 	int       state = 0;
 
-	SPI_connect_wrapper(&state);
 	/*
 	 * Don't catch errors in start_workers_from_dblist. Since this is the
 	 * startup worker for diskquota launcher. If error happens, we just let
 	 * launcher exits.
 	 */
+	SPI_connect_wrapper(&state);
 
 	ret = SPI_execute("select dbid from diskquota_namespace.database_list;", true, 0);
 	if (ret != SPI_OK_SELECT)

--- a/src/diskquota.c
+++ b/src/diskquota.c
@@ -176,9 +176,8 @@ static bool
 is_altering_extension_to_default_version(char *version)
 {
 	int  spi_ret;
-	bool ret = false;
-	bool connected;
-	SPI_connect_wrapper(&connected);
+	bool ret       = false;
+	bool connected = SPI_connect_wrapper();
 	spi_ret = SPI_execute("select default_version from pg_available_extensions where name ='diskquota'", true, 0);
 	if (spi_ret != SPI_OK_SELECT)
 		elog(ERROR, "[diskquota] failed to select diskquota default version during diskquota update.");
@@ -991,7 +990,7 @@ create_monitor_db_table(void)
 	 */
 	PG_TRY();
 	{
-		SPI_connect_wrapper(&connected);
+		connected = SPI_connect_wrapper();
 		PushActiveSnapshot(GetTransactionSnapshot());
 		pushed_active_snap = true;
 
@@ -1039,7 +1038,6 @@ init_database_list(void)
 	int       num = 0;
 	int       ret;
 	int       i;
-	bool      connected;
 
 	/*
 	 * Don't catch errors in start_workers_from_dblist. Since this is the
@@ -1049,8 +1047,8 @@ init_database_list(void)
 	StartTransactionCommand();
 	PushActiveSnapshot(GetTransactionSnapshot());
 
-	SPI_connect_wrapper(&connected);
-	ret = SPI_execute("select dbid from diskquota_namespace.database_list;", true, 0);
+	bool connected = SPI_connect_wrapper();
+	ret            = SPI_execute("select dbid from diskquota_namespace.database_list;", true, 0);
 	if (ret != SPI_OK_SELECT)
 	{
 		int saved_errno = errno;
@@ -1348,8 +1346,7 @@ add_dbid_to_database_list(Oid dbid)
 	Oid   argt[1] = {OIDOID};
 	Datum argv[1] = {ObjectIdGetDatum(dbid)};
 
-	bool connected;
-	SPI_connect_wrapper(&connected);
+	bool connected = SPI_connect_wrapper();
 
 	ret = SPI_execute_with_args("select * from diskquota_namespace.database_list where dbid = $1", 1, argt, argv, NULL,
 	                            true, 0);
@@ -1394,8 +1391,7 @@ static void
 del_dbid_from_database_list(Oid dbid)
 {
 	int  ret;
-	bool connected;
-	SPI_connect_wrapper(&connected);
+	bool connected = SPI_connect_wrapper();
 
 	/* errors will be cached in outer function */
 	ret = SPI_execute_with_args("delete from diskquota_namespace.database_list where dbid = $1", 1,
@@ -1607,9 +1603,8 @@ static const char *
 diskquota_status_schema_version()
 {
 	static char ret_version[64];
-	bool        connected;
-	SPI_connect_wrapper(&connected);
-	int ret = SPI_execute("select extversion from pg_extension where extname = 'diskquota'", true, 0);
+	bool        connected = SPI_connect_wrapper();
+	int         ret       = SPI_execute("select extversion from pg_extension where extname = 'diskquota'", true, 0);
 
 	if (ret != SPI_OK_SELECT || SPI_processed != 1)
 	{

--- a/src/diskquota.h
+++ b/src/diskquota.h
@@ -319,6 +319,6 @@ extern HTAB *DiskquotaShmemInitHash(const char *name, long init_size, long max_s
 extern void  refresh_monitored_dbid_cache(void);
 extern HASHACTION check_hash_fullness(HTAB *hashp, int max_size, const char *warning_message,
                                       TimestampTz *last_overflow_report);
-void              SPI_connect_my(bool *connected, bool *pushed_active_snap, bool *ret, bool *transaction);
-void              SPI_finish_my(bool connected, bool pushed_active_snap, bool ret, bool transaction);
+void              SPI_connect_my(bool *connected, bool *pushed_active_snap, bool *commit, bool *transaction);
+void              SPI_finish_my(bool connected, bool pushed_active_snap, bool commit, bool transaction);
 #endif

--- a/src/diskquota.h
+++ b/src/diskquota.h
@@ -75,6 +75,14 @@ extern int diskquota_worker_timeout;
 #define DiskquotaGetRelstorage(classForm) (0)
 #endif /* GP_VERSION_NUM */
 
+typedef struct
+{
+	bool is_connected;
+	bool is_active_snapshot_pushed;
+	bool do_commit;
+	bool is_under_transaction;
+} SPI_state;
+
 typedef enum
 {
 	NAMESPACE_QUOTA = 0,
@@ -319,6 +327,6 @@ extern HTAB *DiskquotaShmemInitHash(const char *name, long init_size, long max_s
 extern void  refresh_monitored_dbid_cache(void);
 extern HASHACTION check_hash_fullness(HTAB *hashp, int max_size, const char *warning_message,
                                       TimestampTz *last_overflow_report);
-void              SPI_connect_my(bool *connected, bool *pushed_active_snap, bool *commit, bool *transaction);
-void              SPI_finish_my(bool connected, bool pushed_active_snap, bool commit, bool transaction);
+void              SPI_connect_my(SPI_state *state);
+void              SPI_finish_my(const SPI_state *state);
 #endif

--- a/src/diskquota.h
+++ b/src/diskquota.h
@@ -319,6 +319,6 @@ extern HTAB *DiskquotaShmemInitHash(const char *name, long init_size, long max_s
 extern void  refresh_monitored_dbid_cache(void);
 extern HASHACTION check_hash_fullness(HTAB *hashp, int max_size, const char *warning_message,
                                       TimestampTz *last_overflow_report);
-void              SPI_connect_my(bool *connected, bool *pushed_active_snap, bool *ret);
-void              SPI_finish_my(bool connected, bool pushed_active_snap, bool ret);
+void              SPI_connect_my(bool *connected, bool *pushed_active_snap, bool *ret, bool *transaction);
+void              SPI_finish_my(bool connected, bool pushed_active_snap, bool ret, bool transaction);
 #endif

--- a/src/diskquota.h
+++ b/src/diskquota.h
@@ -320,5 +320,5 @@ extern void  refresh_monitored_dbid_cache(void);
 extern HASHACTION check_hash_fullness(HTAB *hashp, int max_size, const char *warning_message,
                                       TimestampTz *last_overflow_report);
 bool              SPI_connect_if_not_yet(void);
-void              SPI_finish_if_connected(bool connected);
+void              SPI_finish_if(bool connected);
 #endif

--- a/src/diskquota.h
+++ b/src/diskquota.h
@@ -75,14 +75,6 @@ extern int diskquota_worker_timeout;
 #define DiskquotaGetRelstorage(classForm) (0)
 #endif /* GP_VERSION_NUM */
 
-enum
-{
-	IS_CONNECTED              = 1 << 0,
-	IS_ACTIVE_SNAPSHOT_PUSHED = 1 << 1,
-	IS_ABORT                  = 1 << 2,
-	IS_UNDER_TRANSACTION      = 1 << 3,
-};
-
 typedef enum
 {
 	NAMESPACE_QUOTA = 0,
@@ -327,6 +319,6 @@ extern HTAB *DiskquotaShmemInitHash(const char *name, long init_size, long max_s
 extern void  refresh_monitored_dbid_cache(void);
 extern HASHACTION check_hash_fullness(HTAB *hashp, int max_size, const char *warning_message,
                                       TimestampTz *last_overflow_report);
-void              SPI_connect_wrapper(int *state);
-void              SPI_finish_wrapper(int state);
+void              SPI_connect_wrapper(bool *connected);
+void              SPI_finish_wrapper(bool connected);
 #endif

--- a/src/diskquota.h
+++ b/src/diskquota.h
@@ -319,6 +319,6 @@ extern HTAB *DiskquotaShmemInitHash(const char *name, long init_size, long max_s
 extern void  refresh_monitored_dbid_cache(void);
 extern HASHACTION check_hash_fullness(HTAB *hashp, int max_size, const char *warning_message,
                                       TimestampTz *last_overflow_report);
-bool              SPI_connect_wrapper(void);
-void              SPI_finish_wrapper(bool connected);
+bool              SPI_connect_if_not_yet(void);
+void              SPI_finish_if_connected(bool connected);
 #endif

--- a/src/diskquota.h
+++ b/src/diskquota.h
@@ -75,13 +75,13 @@ extern int diskquota_worker_timeout;
 #define DiskquotaGetRelstorage(classForm) (0)
 #endif /* GP_VERSION_NUM */
 
-typedef struct
+enum
 {
-	bool is_connected;
-	bool is_active_snapshot_pushed;
-	bool do_commit;
-	bool is_under_transaction;
-} SPI_state;
+	is_connected              = 1 << 0,
+	is_active_snapshot_pushed = 1 << 1,
+	is_abort                  = 1 << 2,
+	is_under_transaction      = 1 << 3,
+};
 
 typedef enum
 {
@@ -327,6 +327,6 @@ extern HTAB *DiskquotaShmemInitHash(const char *name, long init_size, long max_s
 extern void  refresh_monitored_dbid_cache(void);
 extern HASHACTION check_hash_fullness(HTAB *hashp, int max_size, const char *warning_message,
                                       TimestampTz *last_overflow_report);
-void              SPI_connect_wrapper(SPI_state *state);
-void              SPI_finish_wrapper(const SPI_state *state);
+int               SPI_connect_wrapper(void);
+void              SPI_finish_wrapper(int state);
 #endif

--- a/src/diskquota.h
+++ b/src/diskquota.h
@@ -327,6 +327,6 @@ extern HTAB *DiskquotaShmemInitHash(const char *name, long init_size, long max_s
 extern void  refresh_monitored_dbid_cache(void);
 extern HASHACTION check_hash_fullness(HTAB *hashp, int max_size, const char *warning_message,
                                       TimestampTz *last_overflow_report);
-void              SPI_connect_my(SPI_state *state);
-void              SPI_finish_my(const SPI_state *state);
+void              SPI_connect_wrapper(SPI_state *state);
+void              SPI_finish_wrapper(const SPI_state *state);
 #endif

--- a/src/diskquota.h
+++ b/src/diskquota.h
@@ -319,6 +319,6 @@ extern HTAB *DiskquotaShmemInitHash(const char *name, long init_size, long max_s
 extern void  refresh_monitored_dbid_cache(void);
 extern HASHACTION check_hash_fullness(HTAB *hashp, int max_size, const char *warning_message,
                                       TimestampTz *last_overflow_report);
-void              SPI_connect_wrapper(bool *connected);
+bool              SPI_connect_wrapper(void);
 void              SPI_finish_wrapper(bool connected);
 #endif

--- a/src/diskquota.h
+++ b/src/diskquota.h
@@ -320,5 +320,5 @@ extern void  refresh_monitored_dbid_cache(void);
 extern HASHACTION check_hash_fullness(HTAB *hashp, int max_size, const char *warning_message,
                                       TimestampTz *last_overflow_report);
 bool              SPI_connect_if_not_yet(void);
-void              SPI_finish_if(bool connected);
+void              SPI_finish_if(bool connected_in_this_function);
 #endif

--- a/src/diskquota.h
+++ b/src/diskquota.h
@@ -77,10 +77,10 @@ extern int diskquota_worker_timeout;
 
 enum
 {
-	is_connected              = 1 << 0,
-	is_active_snapshot_pushed = 1 << 1,
-	is_abort                  = 1 << 2,
-	is_under_transaction      = 1 << 3,
+	IS_CONNECTED              = 1 << 0,
+	IS_ACTIVE_SNAPSHOT_PUSHED = 1 << 1,
+	IS_ABORT                  = 1 << 2,
+	IS_UNDER_TRANSACTION      = 1 << 3,
 };
 
 typedef enum

--- a/src/diskquota.h
+++ b/src/diskquota.h
@@ -327,6 +327,6 @@ extern HTAB *DiskquotaShmemInitHash(const char *name, long init_size, long max_s
 extern void  refresh_monitored_dbid_cache(void);
 extern HASHACTION check_hash_fullness(HTAB *hashp, int max_size, const char *warning_message,
                                       TimestampTz *last_overflow_report);
-int               SPI_connect_wrapper(void);
+void              SPI_connect_wrapper(int *state);
 void              SPI_finish_wrapper(int state);
 #endif

--- a/src/diskquota.h
+++ b/src/diskquota.h
@@ -319,4 +319,6 @@ extern HTAB *DiskquotaShmemInitHash(const char *name, long init_size, long max_s
 extern void  refresh_monitored_dbid_cache(void);
 extern HASHACTION check_hash_fullness(HTAB *hashp, int max_size, const char *warning_message,
                                       TimestampTz *last_overflow_report);
+void              SPI_connect_my(bool *connected, bool *pushed_active_snap, bool *ret);
+void              SPI_finish_my(bool connected, bool pushed_active_snap, bool ret);
 #endif

--- a/src/diskquota_utility.c
+++ b/src/diskquota_utility.c
@@ -124,8 +124,6 @@ static void   check_role(Oid roleoid, char *rolname, int64 quota_limit_mb);
 Datum
 init_table_size_table(PG_FUNCTION_ARGS)
 {
-	int ret;
-
 	RangeVar *rv;
 	Relation  rel;
 	/*
@@ -161,7 +159,7 @@ init_table_size_table(PG_FUNCTION_ARGS)
 	bool connected_in_this_function = SPI_connect_if_not_yet();
 
 	/* delete all the table size info in table_size if exist. */
-	ret = SPI_execute("truncate table diskquota.table_size", false, 0);
+	int ret = SPI_execute("truncate table diskquota.table_size", false, 0);
 	if (ret != SPI_OK_UTILITY) elog(ERROR, "cannot truncate table_size table: error code %d", ret);
 
 	ret = SPI_execute(

--- a/src/diskquota_utility.c
+++ b/src/diskquota_utility.c
@@ -158,7 +158,7 @@ init_table_size_table(PG_FUNCTION_ARGS)
 	 * They do not work on entry db since we do not support dispatching
 	 * from entry-db currently.
 	 */
-	bool connected = SPI_connect_wrapper();
+	bool connected = SPI_connect_if_not_yet();
 
 	/* delete all the table size info in table_size if exist. */
 	ret = SPI_execute("truncate table diskquota.table_size", false, 0);
@@ -200,7 +200,7 @@ init_table_size_table(PG_FUNCTION_ARGS)
 	                            NULL, false, 0);
 	if (ret != SPI_OK_UPDATE) elog(ERROR, "cannot update state table: error code %d", ret);
 
-	SPI_finish_wrapper(connected);
+	SPI_finish_if_connected(connected);
 	PG_RETURN_VOID();
 }
 
@@ -479,7 +479,7 @@ is_database_empty(void)
 	 * If error happens in is_database_empty, just return error messages to
 	 * the client side. So there is no need to catch the error.
 	 */
-	bool connected = SPI_connect_wrapper();
+	bool connected = SPI_connect_if_not_yet();
 
 	ret = SPI_execute(
 	        "INSERT INTO diskquota.state SELECT (count(relname) = 0)::int "
@@ -516,7 +516,7 @@ is_database_empty(void)
 	/*
 	 * And finish our transaction.
 	 */
-	SPI_finish_wrapper(connected);
+	SPI_finish_if_connected(connected);
 	return is_empty;
 }
 
@@ -810,7 +810,7 @@ set_quota_config_internal(Oid targetoid, int64 quota_limit_mb, QuotaType type, f
 	/* Report error if diskquota is not ready. */
 	do_check_diskquota_state_is_ready();
 
-	bool connected = SPI_connect_wrapper();
+	bool connected = SPI_connect_if_not_yet();
 	/*
 	 * If error happens in set_quota_config_internal, just return error messages to
 	 * the client side. So there is no need to catch the error.
@@ -912,7 +912,7 @@ set_quota_config_internal(Oid targetoid, int64 quota_limit_mb, QuotaType type, f
 		}
 	}
 
-	SPI_finish_wrapper(connected);
+	SPI_finish_if_connected(connected);
 }
 
 static int
@@ -922,7 +922,7 @@ set_target_internal(Oid primaryoid, Oid spcoid, int64 quota_limit_mb, QuotaType 
 	int   row_id  = -1;
 	bool  is_null = false;
 	Datum v;
-	bool  connected = SPI_connect_wrapper();
+	bool  connected = SPI_connect_if_not_yet();
 	/*
 	 * If error happens in set_target_internal, just return error messages to
 	 * the client side. So there is no need to catch the error.
@@ -1004,7 +1004,7 @@ set_target_internal(Oid primaryoid, Oid spcoid, int64 quota_limit_mb, QuotaType 
 		row_id = DatumGetInt32(v);
 	}
 
-	SPI_finish_wrapper(connected);
+	SPI_finish_if_connected(connected);
 
 	/* No need to update the target table */
 
@@ -1153,7 +1153,7 @@ set_per_segment_quota(PG_FUNCTION_ARGS)
 	ereportif(ratio == 0, ERROR,
 	          (errcode(ERRCODE_INVALID_PARAMETER_VALUE), errmsg("per segment quota ratio can not be set to 0")));
 
-	bool connected = SPI_connect_wrapper();
+	bool connected = SPI_connect_if_not_yet();
 	/*
 	 * lock table quota_config table in exlusive mode
 	 *
@@ -1206,7 +1206,7 @@ set_per_segment_quota(PG_FUNCTION_ARGS)
 	/*
 	 * And finish our transaction.
 	 */
-	SPI_finish_wrapper(connected);
+	SPI_finish_if_connected(connected);
 	PG_RETURN_VOID();
 }
 
@@ -1214,7 +1214,7 @@ int
 worker_spi_get_extension_version(int *major, int *minor)
 {
 	StartTransactionCommand();
-	bool connected = SPI_connect_wrapper();
+	bool connected = SPI_connect_if_not_yet();
 	PushActiveSnapshot(GetTransactionSnapshot());
 
 	int ret = SPI_execute("select extversion from pg_extension where extname = 'diskquota'", true, 0);
@@ -1260,7 +1260,7 @@ worker_spi_get_extension_version(int *major, int *minor)
 	ret = 0;
 
 out:
-	SPI_finish_wrapper(connected);
+	SPI_finish_if_connected(connected);
 	PopActiveSnapshot();
 	CommitTransactionCommand();
 
@@ -1280,7 +1280,7 @@ List *
 get_rel_oid_list(bool is_init)
 {
 	List *oidlist   = NIL;
-	bool  connected = SPI_connect_wrapper();
+	bool  connected = SPI_connect_if_not_yet();
 
 #define SELECT_FROM_PG_CATALOG_PG_CLASS "select oid from pg_catalog.pg_class where oid >= $1 and relkind in ('r', 'm')"
 
@@ -1328,7 +1328,7 @@ get_rel_oid_list(bool is_init)
 			MemoryContextSwitchTo(oldcontext);
 		}
 	}
-	SPI_finish_wrapper(connected);
+	SPI_finish_if_connected(connected);
 	return oidlist;
 }
 
@@ -1567,7 +1567,7 @@ get_per_segment_ratio(Oid spcoid)
 
 	if (!OidIsValid(spcoid)) return segratio;
 
-	bool connected = SPI_connect_wrapper();
+	bool connected = SPI_connect_if_not_yet();
 	/*
 	 * using row share lock to lock TABLESPACE_QUTAO
 	 * row to avoid concurrently updating the segratio
@@ -1601,7 +1601,7 @@ get_per_segment_ratio(Oid spcoid)
 			segratio = DatumGetFloat4(dat);
 		}
 	}
-	SPI_finish_wrapper(connected);
+	SPI_finish_if_connected(connected);
 	return segratio;
 }
 
@@ -1693,7 +1693,7 @@ check_hash_fullness(HTAB *hashp, int max_size, const char *warning_message, Time
 }
 
 bool
-SPI_connect_wrapper(void)
+SPI_connect_if_not_yet(void)
 {
 	if (SPI_context()) return false;
 
@@ -1707,7 +1707,7 @@ SPI_connect_wrapper(void)
 }
 
 void
-SPI_finish_wrapper(bool connected)
+SPI_finish_if_connected(bool connected)
 {
 	if (!connected || !SPI_context()) return;
 

--- a/src/diskquota_utility.c
+++ b/src/diskquota_utility.c
@@ -1732,7 +1732,7 @@ SPI_finish_my(bool connected, bool pushed_active_snap, bool ret)
 	if (pushed_active_snap) PopActiveSnapshot();
 	if (connected && (rc = SPI_finish()) != SPI_OK_FINISH)
 		ereport(WARNING, (errcode(ERRCODE_INTERNAL_ERROR), errmsg("[diskquota] SPI_finish failed"),
-		                errdetail("%s", SPI_result_code_string(rc))));
+		                  errdetail("%s", SPI_result_code_string(rc))));
 	if (ret)
 		CommitTransactionCommand();
 	else

--- a/src/diskquota_utility.c
+++ b/src/diskquota_utility.c
@@ -1237,9 +1237,10 @@ int
 worker_spi_get_extension_version(int *major, int *minor)
 {
 	int state = 0;
-	int ret   = SPI_execute("select extversion from pg_extension where extname = 'diskquota'", true, 0);
 
 	SPI_connect_wrapper(&state);
+
+	int ret = SPI_execute("select extversion from pg_extension where extname = 'diskquota'", true, 0);
 
 	if (SPI_processed == 0)
 	{
@@ -1300,25 +1301,24 @@ List *
 get_rel_oid_list(bool is_init)
 {
 	List *oidlist = NIL;
-	int   ret;
-	int   state = 0;
+	int   state   = 0;
 
 	SPI_connect_wrapper(&state);
 
 #define SELECT_FROM_PG_CATALOG_PG_CLASS "select oid from pg_catalog.pg_class where oid >= $1 and relkind in ('r', 'm')"
 
-	ret = SPI_execute_with_args(is_init ? SELECT_FROM_PG_CATALOG_PG_CLASS
-	                                    " union distinct"
-	                                    " select tableid from diskquota.table_size where segid = -1"
-	                                    : SELECT_FROM_PG_CATALOG_PG_CLASS,
-	                            1,
-	                            (Oid[]){
-	                                    OIDOID,
-	                            },
-	                            (Datum[]){
-	                                    ObjectIdGetDatum(FirstNormalObjectId),
-	                            },
-	                            NULL, false, 0);
+	int ret = SPI_execute_with_args(is_init ? SELECT_FROM_PG_CATALOG_PG_CLASS
+	                                        " union distinct"
+	                                        " select tableid from diskquota.table_size where segid = -1"
+	                                        : SELECT_FROM_PG_CATALOG_PG_CLASS,
+	                                1,
+	                                (Oid[]){
+	                                        OIDOID,
+	                                },
+	                                (Datum[]){
+	                                        ObjectIdGetDatum(FirstNormalObjectId),
+	                                },
+	                                NULL, false, 0);
 
 #undef SELECT_FROM_PG_CATALOG_PG_CLASS
 
@@ -1753,7 +1753,7 @@ SPI_finish_wrapper(int state)
 
 	if ((state & IS_CONNECTED) && (rc = SPI_finish()) != SPI_OK_FINISH)
 		ereport(WARNING, (errcode(ERRCODE_INTERNAL_ERROR), errmsg("[diskquota] SPI_finish failed"),
-		                errdetail("%s", SPI_result_code_string(rc))));
+		                  errdetail("%s", SPI_result_code_string(rc))));
 
 	if (state & IS_UNDER_TRANSACTION)
 	{

--- a/src/diskquota_utility.c
+++ b/src/diskquota_utility.c
@@ -1697,11 +1697,11 @@ SPI_connect_wrapper(void)
 {
 	if (SPI_context()) return false;
 
-	int rc;
+	int rc = SPI_connect();
 
-	if ((rc = SPI_connect()) != SPI_OK_CONNECT)
-		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR), errmsg("[diskquota] SPI_connect failed"),
-		                errdetail("%s", SPI_result_code_string(rc))));
+	ereportif(rc != SPI_OK_CONNECT, ERROR,
+	          (errcode(ERRCODE_INTERNAL_ERROR), errmsg("[diskquota] SPI_connect failed"),
+	           errdetail("%s", SPI_result_code_string(rc))));
 
 	return true;
 }
@@ -1709,11 +1709,11 @@ SPI_connect_wrapper(void)
 void
 SPI_finish_wrapper(bool connected)
 {
-	if (!connected) return;
+	if (!connected || !SPI_context()) return;
 
-	int rc;
+	int rc = SPI_finish();
 
-	if (SPI_context() && (rc = SPI_finish()) != SPI_OK_FINISH)
-		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR), errmsg("[diskquota] SPI_finish failed"),
-		                errdetail("%s", SPI_result_code_string(rc))));
+	ereportif(rc != SPI_OK_FINISH, ERROR,
+	          (errcode(ERRCODE_INTERNAL_ERROR), errmsg("[diskquota] SPI_finish failed"),
+	           errdetail("%s", SPI_result_code_string(rc))));
 }

--- a/src/diskquota_utility.c
+++ b/src/diskquota_utility.c
@@ -469,7 +469,6 @@ diskquota_resume(PG_FUNCTION_ARGS)
 static bool
 is_database_empty(void)
 {
-	int       ret;
 	TupleDesc tupdesc;
 	bool      is_empty = false;
 
@@ -479,7 +478,7 @@ is_database_empty(void)
 	 */
 	bool connected_in_this_function = SPI_connect_if_not_yet();
 
-	ret = SPI_execute(
+	int ret = SPI_execute(
 	        "INSERT INTO diskquota.state SELECT (count(relname) = 0)::int "
 	        "FROM "
 	        "  pg_class AS c, "

--- a/src/diskquota_utility.c
+++ b/src/diskquota_utility.c
@@ -1236,10 +1236,8 @@ set_per_segment_quota(PG_FUNCTION_ARGS)
 int
 worker_spi_get_extension_version(int *major, int *minor)
 {
-	int ret;
 	int state = SPI_connect_wrapper();
-
-	ret = SPI_execute("select extversion from pg_extension where extname = 'diskquota'", true, 0);
+	int ret   = SPI_execute("select extversion from pg_extension where extname = 'diskquota'", true, 0);
 
 	if (SPI_processed == 0)
 	{

--- a/src/diskquota_utility.c
+++ b/src/diskquota_utility.c
@@ -200,7 +200,7 @@ init_table_size_table(PG_FUNCTION_ARGS)
 	                            NULL, false, 0);
 	if (ret != SPI_OK_UPDATE) elog(ERROR, "cannot update state table: error code %d", ret);
 
-	SPI_finish_if_connected(connected);
+	SPI_finish_if(connected);
 	PG_RETURN_VOID();
 }
 
@@ -516,7 +516,7 @@ is_database_empty(void)
 	/*
 	 * And finish our transaction.
 	 */
-	SPI_finish_if_connected(connected);
+	SPI_finish_if(connected);
 	return is_empty;
 }
 
@@ -912,7 +912,7 @@ set_quota_config_internal(Oid targetoid, int64 quota_limit_mb, QuotaType type, f
 		}
 	}
 
-	SPI_finish_if_connected(connected);
+	SPI_finish_if(connected);
 }
 
 static int
@@ -1004,7 +1004,7 @@ set_target_internal(Oid primaryoid, Oid spcoid, int64 quota_limit_mb, QuotaType 
 		row_id = DatumGetInt32(v);
 	}
 
-	SPI_finish_if_connected(connected);
+	SPI_finish_if(connected);
 
 	/* No need to update the target table */
 
@@ -1206,7 +1206,7 @@ set_per_segment_quota(PG_FUNCTION_ARGS)
 	/*
 	 * And finish our transaction.
 	 */
-	SPI_finish_if_connected(connected);
+	SPI_finish_if(connected);
 	PG_RETURN_VOID();
 }
 
@@ -1260,7 +1260,7 @@ worker_spi_get_extension_version(int *major, int *minor)
 	ret = 0;
 
 out:
-	SPI_finish_if_connected(connected);
+	SPI_finish_if(connected);
 	PopActiveSnapshot();
 	CommitTransactionCommand();
 
@@ -1328,7 +1328,7 @@ get_rel_oid_list(bool is_init)
 			MemoryContextSwitchTo(oldcontext);
 		}
 	}
-	SPI_finish_if_connected(connected);
+	SPI_finish_if(connected);
 	return oidlist;
 }
 
@@ -1601,7 +1601,7 @@ get_per_segment_ratio(Oid spcoid)
 			segratio = DatumGetFloat4(dat);
 		}
 	}
-	SPI_finish_if_connected(connected);
+	SPI_finish_if(connected);
 	return segratio;
 }
 
@@ -1707,7 +1707,7 @@ SPI_connect_if_not_yet(void)
 }
 
 void
-SPI_finish_if_connected(bool connected)
+SPI_finish_if(bool connected)
 {
 	if (!connected || !SPI_context()) return;
 

--- a/src/diskquota_utility.c
+++ b/src/diskquota_utility.c
@@ -46,6 +46,7 @@
 #include "utils/faultinjector.h"
 #include "utils/fmgroids.h"
 #include "utils/formatting.h"
+#include "utils/memutils.h"
 #include "utils/numeric.h"
 #include "libpq-fe.h"
 #include "funcapi.h"

--- a/src/diskquota_utility.c
+++ b/src/diskquota_utility.c
@@ -1338,7 +1338,7 @@ get_rel_oid_list(bool is_init)
 		if (!isnull)
 		{
 			List         *indexIds;
-			MemoryContext oldcontext = MemoryContextSwitchTo(TopMemoryContext);
+			MemoryContext oldcontext = MemoryContextSwitchTo(CurTransactionContext);
 			oidlist                  = lappend_oid(oidlist, oid);
 			indexIds                 = diskquota_get_index_list(oid);
 			if (indexIds != NIL)

--- a/src/diskquota_utility.c
+++ b/src/diskquota_utility.c
@@ -1695,6 +1695,8 @@ check_hash_fullness(HTAB *hashp, int max_size, const char *warning_message, Time
 bool
 SPI_connect_wrapper(void)
 {
+	if (SPI_context()) return false;
+
 	int rc;
 
 	if ((rc = SPI_connect()) != SPI_OK_CONNECT)

--- a/src/diskquota_utility.c
+++ b/src/diskquota_utility.c
@@ -1239,7 +1239,7 @@ worker_spi_get_extension_version(int *major, int *minor)
 	SPI_state state;
 	int       ret;
 
-	SPI_connect_my(&state);
+	SPI_connect_wrapper(&state);
 
 	ret = SPI_execute("select extversion from pg_extension where extname = 'diskquota'", true, 0);
 
@@ -1284,7 +1284,7 @@ worker_spi_get_extension_version(int *major, int *minor)
 	ret = 0;
 
 out:
-	SPI_finish_my(&state);
+	SPI_finish_wrapper(&state);
 
 	return ret;
 }
@@ -1305,7 +1305,7 @@ get_rel_oid_list(bool is_init)
 	List     *oidlist = NIL;
 	int       ret;
 
-	SPI_connect_my(&state);
+	SPI_connect_wrapper(&state);
 
 #define SELECT_FROM_PG_CATALOG_PG_CLASS "select oid from pg_catalog.pg_class where oid >= $1 and relkind in ('r', 'm')"
 
@@ -1353,7 +1353,7 @@ get_rel_oid_list(bool is_init)
 			MemoryContextSwitchTo(oldcontext);
 		}
 	}
-	SPI_finish_my(&state);
+	SPI_finish_wrapper(&state);
 	return oidlist;
 }
 
@@ -1716,7 +1716,7 @@ check_hash_fullness(HTAB *hashp, int max_size, const char *warning_message, Time
 }
 
 void
-SPI_connect_my(SPI_state *state)
+SPI_connect_wrapper(SPI_state *state)
 {
 	int rc;
 
@@ -1743,7 +1743,7 @@ SPI_connect_my(SPI_state *state)
 }
 
 void
-SPI_finish_my(const SPI_state *state)
+SPI_finish_wrapper(const SPI_state *state)
 {
 	int rc;
 

--- a/src/diskquota_utility.c
+++ b/src/diskquota_utility.c
@@ -158,7 +158,7 @@ init_table_size_table(PG_FUNCTION_ARGS)
 	 * They do not work on entry db since we do not support dispatching
 	 * from entry-db currently.
 	 */
-	bool connected = SPI_connect_if_not_yet();
+	bool connected_in_this_function = SPI_connect_if_not_yet();
 
 	/* delete all the table size info in table_size if exist. */
 	ret = SPI_execute("truncate table diskquota.table_size", false, 0);
@@ -200,7 +200,7 @@ init_table_size_table(PG_FUNCTION_ARGS)
 	                            NULL, false, 0);
 	if (ret != SPI_OK_UPDATE) elog(ERROR, "cannot update state table: error code %d", ret);
 
-	SPI_finish_if(connected);
+	SPI_finish_if(connected_in_this_function);
 	PG_RETURN_VOID();
 }
 
@@ -479,7 +479,7 @@ is_database_empty(void)
 	 * If error happens in is_database_empty, just return error messages to
 	 * the client side. So there is no need to catch the error.
 	 */
-	bool connected = SPI_connect_if_not_yet();
+	bool connected_in_this_function = SPI_connect_if_not_yet();
 
 	ret = SPI_execute(
 	        "INSERT INTO diskquota.state SELECT (count(relname) = 0)::int "
@@ -516,7 +516,7 @@ is_database_empty(void)
 	/*
 	 * And finish our transaction.
 	 */
-	SPI_finish_if(connected);
+	SPI_finish_if(connected_in_this_function);
 	return is_empty;
 }
 
@@ -810,7 +810,7 @@ set_quota_config_internal(Oid targetoid, int64 quota_limit_mb, QuotaType type, f
 	/* Report error if diskquota is not ready. */
 	do_check_diskquota_state_is_ready();
 
-	bool connected = SPI_connect_if_not_yet();
+	bool connected_in_this_function = SPI_connect_if_not_yet();
 	/*
 	 * If error happens in set_quota_config_internal, just return error messages to
 	 * the client side. So there is no need to catch the error.
@@ -912,7 +912,7 @@ set_quota_config_internal(Oid targetoid, int64 quota_limit_mb, QuotaType type, f
 		}
 	}
 
-	SPI_finish_if(connected);
+	SPI_finish_if(connected_in_this_function);
 }
 
 static int
@@ -922,7 +922,7 @@ set_target_internal(Oid primaryoid, Oid spcoid, int64 quota_limit_mb, QuotaType 
 	int   row_id  = -1;
 	bool  is_null = false;
 	Datum v;
-	bool  connected = SPI_connect_if_not_yet();
+	bool  connected_in_this_function = SPI_connect_if_not_yet();
 	/*
 	 * If error happens in set_target_internal, just return error messages to
 	 * the client side. So there is no need to catch the error.
@@ -1004,7 +1004,7 @@ set_target_internal(Oid primaryoid, Oid spcoid, int64 quota_limit_mb, QuotaType 
 		row_id = DatumGetInt32(v);
 	}
 
-	SPI_finish_if(connected);
+	SPI_finish_if(connected_in_this_function);
 
 	/* No need to update the target table */
 
@@ -1153,7 +1153,7 @@ set_per_segment_quota(PG_FUNCTION_ARGS)
 	ereportif(ratio == 0, ERROR,
 	          (errcode(ERRCODE_INVALID_PARAMETER_VALUE), errmsg("per segment quota ratio can not be set to 0")));
 
-	bool connected = SPI_connect_if_not_yet();
+	bool connected_in_this_function = SPI_connect_if_not_yet();
 	/*
 	 * lock table quota_config table in exlusive mode
 	 *
@@ -1206,7 +1206,7 @@ set_per_segment_quota(PG_FUNCTION_ARGS)
 	/*
 	 * And finish our transaction.
 	 */
-	SPI_finish_if(connected);
+	SPI_finish_if(connected_in_this_function);
 	PG_RETURN_VOID();
 }
 
@@ -1214,7 +1214,7 @@ int
 worker_spi_get_extension_version(int *major, int *minor)
 {
 	StartTransactionCommand();
-	bool connected = SPI_connect_if_not_yet();
+	bool connected_in_this_function = SPI_connect_if_not_yet();
 	PushActiveSnapshot(GetTransactionSnapshot());
 
 	int ret = SPI_execute("select extversion from pg_extension where extname = 'diskquota'", true, 0);
@@ -1260,7 +1260,7 @@ worker_spi_get_extension_version(int *major, int *minor)
 	ret = 0;
 
 out:
-	SPI_finish_if(connected);
+	SPI_finish_if(connected_in_this_function);
 	PopActiveSnapshot();
 	CommitTransactionCommand();
 
@@ -1279,8 +1279,8 @@ out:
 List *
 get_rel_oid_list(bool is_init)
 {
-	List *oidlist   = NIL;
-	bool  connected = SPI_connect_if_not_yet();
+	List *oidlist                    = NIL;
+	bool  connected_in_this_function = SPI_connect_if_not_yet();
 
 #define SELECT_FROM_PG_CATALOG_PG_CLASS "select oid from pg_catalog.pg_class where oid >= $1 and relkind in ('r', 'm')"
 
@@ -1328,7 +1328,7 @@ get_rel_oid_list(bool is_init)
 			MemoryContextSwitchTo(oldcontext);
 		}
 	}
-	SPI_finish_if(connected);
+	SPI_finish_if(connected_in_this_function);
 	return oidlist;
 }
 
@@ -1567,7 +1567,7 @@ get_per_segment_ratio(Oid spcoid)
 
 	if (!OidIsValid(spcoid)) return segratio;
 
-	bool connected = SPI_connect_if_not_yet();
+	bool connected_in_this_function = SPI_connect_if_not_yet();
 	/*
 	 * using row share lock to lock TABLESPACE_QUTAO
 	 * row to avoid concurrently updating the segratio
@@ -1601,7 +1601,7 @@ get_per_segment_ratio(Oid spcoid)
 			segratio = DatumGetFloat4(dat);
 		}
 	}
-	SPI_finish_if(connected);
+	SPI_finish_if(connected_in_this_function);
 	return segratio;
 }
 
@@ -1707,9 +1707,9 @@ SPI_connect_if_not_yet(void)
 }
 
 void
-SPI_finish_if(bool connected)
+SPI_finish_if(bool connected_in_calling_function)
 {
-	if (!connected || !SPI_context()) return;
+	if (!connected_in_calling_function || !SPI_context()) return;
 
 	int rc = SPI_finish();
 

--- a/src/diskquota_utility.c
+++ b/src/diskquota_utility.c
@@ -926,7 +926,7 @@ set_target_internal(Oid primaryoid, Oid spcoid, int64 quota_limit_mb, QuotaType 
 	bool  is_null = false;
 	Datum v;
 
-	bool connected = 0;
+	bool connected;
 	SPI_connect_wrapper(&connected);
 	/*
 	 * If error happens in set_target_internal, just return error messages to

--- a/src/diskquota_utility.c
+++ b/src/diskquota_utility.c
@@ -1731,7 +1731,7 @@ SPI_finish_my(bool connected, bool pushed_active_snap, bool ret)
 	int rc;
 	if (pushed_active_snap) PopActiveSnapshot();
 	if (connected && (rc = SPI_finish()) != SPI_OK_FINISH)
-		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR), errmsg("[diskquota] SPI_finish failed"),
+		ereport(WARNING, (errcode(ERRCODE_INTERNAL_ERROR), errmsg("[diskquota] SPI_finish failed"),
 		                errdetail("%s", SPI_result_code_string(rc))));
 	if (ret)
 		CommitTransactionCommand();

--- a/src/diskquota_utility.c
+++ b/src/diskquota_utility.c
@@ -1219,9 +1219,11 @@ set_per_segment_quota(PG_FUNCTION_ARGS)
 int
 worker_spi_get_extension_version(int *major, int *minor)
 {
+	StartTransactionCommand();
 	int state = 0;
 
 	SPI_connect_wrapper(&state);
+	PushActiveSnapshot(GetTransactionSnapshot());
 
 	int ret = SPI_execute("select extversion from pg_extension where extname = 'diskquota'", true, 0);
 
@@ -1267,6 +1269,8 @@ worker_spi_get_extension_version(int *major, int *minor)
 
 out:
 	SPI_finish_wrapper(state);
+	PopActiveSnapshot();
+	CommitTransactionCommand();
 
 	return ret;
 }

--- a/src/diskquota_utility.c
+++ b/src/diskquota_utility.c
@@ -1751,9 +1751,9 @@ SPI_finish_wrapper(int state)
 
 	if (state & IS_ACTIVE_SNAPSHOT_PUSHED) PopActiveSnapshot();
 
-	if ((state & IS_CONNECTED) && (rc = SPI_finish()) != SPI_OK_FINISH)
-		ereport(WARNING, (errcode(ERRCODE_INTERNAL_ERROR), errmsg("[diskquota] SPI_finish failed"),
-		                  errdetail("%s", SPI_result_code_string(rc))));
+	if ((state & IS_CONNECTED) && SPI_context() && (rc = SPI_finish()) != SPI_OK_FINISH)
+		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR), errmsg("[diskquota] SPI_finish failed"),
+		                errdetail("%s", SPI_result_code_string(rc))));
 
 	if (state & IS_UNDER_TRANSACTION)
 	{

--- a/src/diskquota_utility.c
+++ b/src/diskquota_utility.c
@@ -1708,8 +1708,6 @@ SPI_connect_wrapper(bool *connected)
 {
 	*connected = false;
 
-	SetCurrentStatementStartTimestamp();
-
 	if (!SPI_context())
 	{
 		int rc;
@@ -1725,9 +1723,12 @@ SPI_connect_wrapper(bool *connected)
 void
 SPI_finish_wrapper(bool connected)
 {
-	int rc;
+	if (connected && SPI_context())
+	{
+		int rc;
 
-	if (connected && SPI_context() && (rc = SPI_finish()) != SPI_OK_FINISH)
-		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR), errmsg("[diskquota] SPI_finish failed"),
-		                errdetail("%s", SPI_result_code_string(rc))));
+		if ((rc = SPI_finish()) != SPI_OK_FINISH)
+			ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR), errmsg("[diskquota] SPI_finish failed"),
+			                errdetail("%s", SPI_result_code_string(rc))));
+	}
 }

--- a/src/diskquota_utility.c
+++ b/src/diskquota_utility.c
@@ -1720,7 +1720,7 @@ SPI_connect_wrapper(void)
 	if (!IsTransactionState())
 	{
 		StartTransactionCommand();
-		state |= is_under_transaction;
+		state |= IS_UNDER_TRANSACTION;
 	}
 
 	if (!SPI_context())
@@ -1728,13 +1728,13 @@ SPI_connect_wrapper(void)
 		if ((rc = SPI_connect()) != SPI_OK_CONNECT)
 			ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR), errmsg("[diskquota] SPI_connect failed"),
 			                errdetail("%s", SPI_result_code_string(rc))));
-		state |= is_connected;
+		state |= IS_CONNECTED;
 	}
 
-	if (state & is_under_transaction)
+	if (state & IS_UNDER_TRANSACTION)
 	{
 		PushActiveSnapshot(GetTransactionSnapshot());
-		state |= is_active_snapshot_pushed;
+		state |= IS_ACTIVE_SNAPSHOT_PUSHED;
 	}
 
 	return state;
@@ -1745,15 +1745,15 @@ SPI_finish_wrapper(int state)
 {
 	int rc;
 
-	if ((state & is_connected) && (rc = SPI_finish()) != SPI_OK_FINISH)
+	if ((state & IS_CONNECTED) && (rc = SPI_finish()) != SPI_OK_FINISH)
 		ereport(WARNING, (errcode(ERRCODE_INTERNAL_ERROR), errmsg("[diskquota] SPI_finish failed"),
 		                  errdetail("%s", SPI_result_code_string(rc))));
 
-	if (state & is_active_snapshot_pushed) PopActiveSnapshot();
+	if (state & IS_ACTIVE_SNAPSHOT_PUSHED) PopActiveSnapshot();
 
-	if (state & is_under_transaction)
+	if (state & IS_UNDER_TRANSACTION)
 	{
-		if (state & is_abort)
+		if (state & IS_ABORT)
 			AbortCurrentTransaction();
 		else
 			CommitTransactionCommand();

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -447,13 +447,6 @@ diskquota_fetch_table_stat(PG_FUNCTION_ARGS)
 	{
 		MemoryContext oldcontext;
 		TupleDesc     tupdesc;
-		int           ret_code = SPI_connect();
-		if (ret_code != SPI_OK_CONNECT)
-		{
-			ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
-			                errmsg("unable to connect to execute internal query. return code: %d.", ret_code)));
-		}
-		SPI_finish();
 
 		/* create a function context for cross-call persistence */
 		funcctx = SRF_FIRSTCALL_INIT();

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -447,6 +447,10 @@ diskquota_fetch_table_stat(PG_FUNCTION_ARGS)
 	{
 		MemoryContext oldcontext;
 		TupleDesc     tupdesc;
+		int           state = 0;
+
+		SPI_connect_wrapper(&state);
+		SPI_finish_wrapper(state);
 
 		/* create a function context for cross-call persistence */
 		funcctx = SRF_FIRSTCALL_INIT();

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -953,7 +953,9 @@ load_table_size(HTAB *local_table_stats_map)
 	SPIPlanPtr                plan;
 	Portal                    portal;
 	char                     *sql   = "select tableid, size, segid from diskquota.table_size";
-	int                       state = SPI_connect_wrapper();
+	int                       state = 0;
+
+	SPI_connect_wrapper(&state);
 
 	if ((plan = SPI_prepare(sql, 0, NULL)) == NULL)
 		ereport(ERROR, (errmsg("[diskquota] SPI_prepare(\"%s\") failed", sql)));

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -447,10 +447,10 @@ diskquota_fetch_table_stat(PG_FUNCTION_ARGS)
 	{
 		MemoryContext oldcontext;
 		TupleDesc     tupdesc;
-		int           state = 0;
+		bool          connected;
 
-		SPI_connect_wrapper(&state);
-		SPI_finish_wrapper(state);
+		SPI_connect_wrapper(&connected);
+		SPI_finish_wrapper(connected);
 
 		/* create a function context for cross-call persistence */
 		funcctx = SRF_FIRSTCALL_INIT();
@@ -949,10 +949,10 @@ load_table_size(HTAB *local_table_stats_map)
 	ActiveTableEntryCombined *quota_entry;
 	SPIPlanPtr                plan;
 	Portal                    portal;
-	char                     *sql   = "select tableid, size, segid from diskquota.table_size";
-	int                       state = 0;
+	char                     *sql = "select tableid, size, segid from diskquota.table_size";
+	bool                      connected;
 
-	SPI_connect_wrapper(&state);
+	SPI_connect_wrapper(&connected);
 
 	if ((plan = SPI_prepare(sql, 0, NULL)) == NULL)
 		ereport(ERROR, (errmsg("[diskquota] SPI_prepare(\"%s\") failed", sql)));
@@ -1028,7 +1028,7 @@ load_table_size(HTAB *local_table_stats_map)
 	SPI_freetuptable(SPI_tuptable);
 	SPI_cursor_close(portal);
 	SPI_freeplan(plan);
-	SPI_finish_wrapper(state);
+	SPI_finish_wrapper(connected);
 }
 
 /*

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -946,7 +946,7 @@ get_active_tables_oid(void)
 static void
 load_table_size(HTAB *local_table_stats_map)
 {
-	bool                      connected, pushed_active_snap, commit, transaction;
+	SPI_state                 state;
 	TupleDesc                 tupdesc;
 	int                       i;
 	bool                      found;
@@ -955,7 +955,7 @@ load_table_size(HTAB *local_table_stats_map)
 	Portal                    portal;
 	char                     *sql = "select tableid, size, segid from diskquota.table_size";
 
-	SPI_connect_my(&connected, &pushed_active_snap, &commit, &transaction);
+	SPI_connect_my(&state);
 
 	if ((plan = SPI_prepare(sql, 0, NULL)) == NULL)
 		ereport(ERROR, (errmsg("[diskquota] SPI_prepare(\"%s\") failed", sql)));
@@ -1031,7 +1031,7 @@ load_table_size(HTAB *local_table_stats_map)
 	SPI_freetuptable(SPI_tuptable);
 	SPI_cursor_close(portal);
 	SPI_freeplan(plan);
-	SPI_finish_my(connected, pushed_active_snap, commit, transaction);
+	SPI_finish_my(&state);
 }
 
 /*

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -448,8 +448,6 @@ diskquota_fetch_table_stat(PG_FUNCTION_ARGS)
 		MemoryContext oldcontext;
 		TupleDesc     tupdesc;
 
-		SPI_finish_if(SPI_connect_if_not_yet());
-
 		/* create a function context for cross-call persistence */
 		funcctx = SRF_FIRSTCALL_INIT();
 

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -955,7 +955,7 @@ load_table_size(HTAB *local_table_stats_map)
 	Portal                    portal;
 	char                     *sql = "select tableid, size, segid from diskquota.table_size";
 
-	SPI_connect_my(&state);
+	SPI_connect_wrapper(&state);
 
 	if ((plan = SPI_prepare(sql, 0, NULL)) == NULL)
 		ereport(ERROR, (errmsg("[diskquota] SPI_prepare(\"%s\") failed", sql)));
@@ -1031,7 +1031,7 @@ load_table_size(HTAB *local_table_stats_map)
 	SPI_freetuptable(SPI_tuptable);
 	SPI_cursor_close(portal);
 	SPI_freeplan(plan);
-	SPI_finish_my(&state);
+	SPI_finish_wrapper(&state);
 }
 
 /*

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -447,10 +447,8 @@ diskquota_fetch_table_stat(PG_FUNCTION_ARGS)
 	{
 		MemoryContext oldcontext;
 		TupleDesc     tupdesc;
-		bool          connected;
 
-		SPI_connect_wrapper(&connected);
-		SPI_finish_wrapper(connected);
+		SPI_finish_wrapper(SPI_connect_wrapper());
 
 		/* create a function context for cross-call persistence */
 		funcctx = SRF_FIRSTCALL_INIT();
@@ -949,10 +947,8 @@ load_table_size(HTAB *local_table_stats_map)
 	ActiveTableEntryCombined *quota_entry;
 	SPIPlanPtr                plan;
 	Portal                    portal;
-	char                     *sql = "select tableid, size, segid from diskquota.table_size";
-	bool                      connected;
-
-	SPI_connect_wrapper(&connected);
+	char                     *sql       = "select tableid, size, segid from diskquota.table_size";
+	bool                      connected = SPI_connect_wrapper();
 
 	if ((plan = SPI_prepare(sql, 0, NULL)) == NULL)
 		ereport(ERROR, (errmsg("[diskquota] SPI_prepare(\"%s\") failed", sql)));

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -947,8 +947,8 @@ load_table_size(HTAB *local_table_stats_map)
 	ActiveTableEntryCombined *quota_entry;
 	SPIPlanPtr                plan;
 	Portal                    portal;
-	char                     *sql       = "select tableid, size, segid from diskquota.table_size";
-	bool                      connected = SPI_connect_if_not_yet();
+	char                     *sql                        = "select tableid, size, segid from diskquota.table_size";
+	bool                      connected_in_this_function = SPI_connect_if_not_yet();
 
 	if ((plan = SPI_prepare(sql, 0, NULL)) == NULL)
 		ereport(ERROR, (errmsg("[diskquota] SPI_prepare(\"%s\") failed", sql)));
@@ -1024,7 +1024,7 @@ load_table_size(HTAB *local_table_stats_map)
 	SPI_freetuptable(SPI_tuptable);
 	SPI_cursor_close(portal);
 	SPI_freeplan(plan);
-	SPI_finish_if(connected);
+	SPI_finish_if(connected_in_this_function);
 }
 
 /*

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -448,7 +448,7 @@ diskquota_fetch_table_stat(PG_FUNCTION_ARGS)
 		MemoryContext oldcontext;
 		TupleDesc     tupdesc;
 
-		SPI_finish_wrapper(SPI_connect_wrapper());
+		SPI_finish_if_connected(SPI_connect_if_not_yet());
 
 		/* create a function context for cross-call persistence */
 		funcctx = SRF_FIRSTCALL_INIT();
@@ -948,7 +948,7 @@ load_table_size(HTAB *local_table_stats_map)
 	SPIPlanPtr                plan;
 	Portal                    portal;
 	char                     *sql       = "select tableid, size, segid from diskquota.table_size";
-	bool                      connected = SPI_connect_wrapper();
+	bool                      connected = SPI_connect_if_not_yet();
 
 	if ((plan = SPI_prepare(sql, 0, NULL)) == NULL)
 		ereport(ERROR, (errmsg("[diskquota] SPI_prepare(\"%s\") failed", sql)));
@@ -1024,7 +1024,7 @@ load_table_size(HTAB *local_table_stats_map)
 	SPI_freetuptable(SPI_tuptable);
 	SPI_cursor_close(portal);
 	SPI_freeplan(plan);
-	SPI_finish_wrapper(connected);
+	SPI_finish_if_connected(connected);
 }
 
 /*

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -448,7 +448,7 @@ diskquota_fetch_table_stat(PG_FUNCTION_ARGS)
 		MemoryContext oldcontext;
 		TupleDesc     tupdesc;
 
-		SPI_finish_if_connected(SPI_connect_if_not_yet());
+		SPI_finish_if(SPI_connect_if_not_yet());
 
 		/* create a function context for cross-call persistence */
 		funcctx = SRF_FIRSTCALL_INIT();
@@ -1024,7 +1024,7 @@ load_table_size(HTAB *local_table_stats_map)
 	SPI_freetuptable(SPI_tuptable);
 	SPI_cursor_close(portal);
 	SPI_freeplan(plan);
-	SPI_finish_if_connected(connected);
+	SPI_finish_if(connected);
 }
 
 /*

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -946,17 +946,14 @@ get_active_tables_oid(void)
 static void
 load_table_size(HTAB *local_table_stats_map)
 {
+	bool                      connected, pushed_active_snap, commit, transaction;
 	TupleDesc                 tupdesc;
 	int                       i;
 	bool                      found;
 	ActiveTableEntryCombined *quota_entry;
 	SPIPlanPtr                plan;
 	Portal                    portal;
-	char                     *sql                = "select tableid, size, segid from diskquota.table_size";
-	bool                      connected          = false;
-	bool                      pushed_active_snap = false;
-	bool                      commit             = true;
-	bool                      transaction        = true;
+	char                     *sql = "select tableid, size, segid from diskquota.table_size";
 
 	SPI_connect_my(&connected, &pushed_active_snap, &commit, &transaction);
 

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -946,16 +946,14 @@ get_active_tables_oid(void)
 static void
 load_table_size(HTAB *local_table_stats_map)
 {
-	SPI_state                 state;
 	TupleDesc                 tupdesc;
 	int                       i;
 	bool                      found;
 	ActiveTableEntryCombined *quota_entry;
 	SPIPlanPtr                plan;
 	Portal                    portal;
-	char                     *sql = "select tableid, size, segid from diskquota.table_size";
-
-	SPI_connect_wrapper(&state);
+	char                     *sql   = "select tableid, size, segid from diskquota.table_size";
+	int                       state = SPI_connect_wrapper();
 
 	if ((plan = SPI_prepare(sql, 0, NULL)) == NULL)
 		ereport(ERROR, (errmsg("[diskquota] SPI_prepare(\"%s\") failed", sql)));
@@ -1031,7 +1029,7 @@ load_table_size(HTAB *local_table_stats_map)
 	SPI_freetuptable(SPI_tuptable);
 	SPI_cursor_close(portal);
 	SPI_freeplan(plan);
-	SPI_finish_wrapper(&state);
+	SPI_finish_wrapper(state);
 }
 
 /*

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -677,6 +677,7 @@ check_diskquota_state_is_ready()
 	bool connected          = false;
 	bool pushed_active_snap = false;
 	bool ret                = true;
+	bool transaction        = true;
 
 	/*
 	 * Cache Errors during SPI functions, for example a segment may be down
@@ -685,7 +686,7 @@ check_diskquota_state_is_ready()
 	 */
 	PG_TRY();
 	{
-		SPI_connect_my(&connected, &pushed_active_snap, &ret);
+		SPI_connect_my(&connected, &pushed_active_snap, &ret, &transaction);
 		is_ready = do_check_diskquota_state_is_ready();
 	}
 	PG_CATCH();
@@ -699,7 +700,7 @@ check_diskquota_state_is_ready()
 		RESUME_INTERRUPTS();
 	}
 	PG_END_TRY();
-	SPI_finish_my(connected, pushed_active_snap, ret);
+	SPI_finish_my(connected, pushed_active_snap, ret, transaction);
 	return is_ready;
 }
 
@@ -786,8 +787,6 @@ refresh_disk_quota_model(bool is_init)
 static void
 refresh_disk_quota_usage(bool is_init)
 {
-	bool  connected                   = false;
-	bool  pushed_active_snap          = false;
 	bool  ret                         = true;
 	HTAB *local_active_table_stat_map = NULL;
 
@@ -798,7 +797,7 @@ refresh_disk_quota_usage(bool is_init)
 	 */
 	PG_TRY();
 	{
-		SPI_connect_my(&connected, &pushed_active_snap, &ret);
+		StartTransactionCommand();
 		/*
 		 * initialization stage all the tables are active. later loop, only the
 		 * tables whose disk size changed will be treated as active
@@ -838,7 +837,10 @@ refresh_disk_quota_usage(bool is_init)
 		RESUME_INTERRUPTS();
 	}
 	PG_END_TRY();
-	SPI_finish_my(connected, pushed_active_snap, ret);
+	if (ret)
+		CommitTransactionCommand();
+	else
+		AbortCurrentTransaction();
 	return;
 }
 
@@ -1125,6 +1127,10 @@ delete_from_table_size_map(char *str)
 {
 	StringInfoData delete_statement;
 	int            ret;
+	bool           connected          = false;
+	bool           pushed_active_snap = false;
+	bool           commit             = true;
+	bool           transaction        = true;
 
 	initStringInfo(&delete_statement);
 	appendStringInfo(&delete_statement,
@@ -1132,10 +1138,12 @@ delete_from_table_size_map(char *str)
 	                 "delete from diskquota.table_size "
 	                 "where (tableid, segid) in ( SELECT * FROM deleted_table );",
 	                 str);
+	SPI_connect_my(&connected, &pushed_active_snap, &commit, &transaction);
 	ret = SPI_execute(delete_statement.data, false, 0);
 	if (ret != SPI_OK_DELETE)
 		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
 		                errmsg("[diskquota] delete_from_table_size_map SPI_execute failed: error code %d", ret)));
+	SPI_finish_my(connected, pushed_active_snap, commit, transaction);
 	pfree(delete_statement.data);
 }
 
@@ -1144,13 +1152,19 @@ insert_into_table_size_map(char *str)
 {
 	StringInfoData insert_statement;
 	int            ret;
+	bool           connected          = false;
+	bool           pushed_active_snap = false;
+	bool           commit             = true;
+	bool           transaction        = true;
 
 	initStringInfo(&insert_statement);
 	appendStringInfo(&insert_statement, "insert into diskquota.table_size values %s;", str);
+	SPI_connect_my(&connected, &pushed_active_snap, &commit, &transaction);
 	ret = SPI_execute(insert_statement.data, false, 0);
 	if (ret != SPI_OK_INSERT)
 		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
 		                errmsg("[diskquota] insert_into_table_size_map SPI_execute failed: error code %d", ret)));
+	SPI_finish_my(connected, pushed_active_snap, commit, transaction);
 	pfree(insert_statement.data);
 }
 
@@ -1200,7 +1214,7 @@ flush_to_table_size(void)
 				}
 			}
 			/* update the table size by delete+insert in table table_size */
-			else if (TableSizeEntryGetFlushFlag(tsentry, i))
+			else // if (TableSizeEntryGetFlushFlag(tsentry, i))
 			{
 				appendStringInfo(&delete_statement, "%s(%u,%d)", (delete_entries_num == 0) ? " " : ", ",
 				                 tsentry->key.reloid, i);
@@ -1387,6 +1401,7 @@ load_quotas(void)
 	bool connected          = false;
 	bool pushed_active_snap = false;
 	bool ret                = true;
+	bool transaction        = true;
 
 	/*
 	 * Cache Errors during SPI functions, for example a segment may be down
@@ -1395,7 +1410,7 @@ load_quotas(void)
 	 */
 	PG_TRY();
 	{
-		SPI_connect_my(&connected, &pushed_active_snap, &ret);
+		SPI_connect_my(&connected, &pushed_active_snap, &ret, &transaction);
 		do_load_quotas();
 	}
 	PG_CATCH();
@@ -1409,7 +1424,7 @@ load_quotas(void)
 		RESUME_INTERRUPTS();
 	}
 	PG_END_TRY();
-	SPI_finish_my(connected, pushed_active_snap, ret);
+	SPI_finish_my(connected, pushed_active_snap, ret, transaction);
 	return ret;
 }
 

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -855,6 +855,7 @@ refresh_disk_quota_usage(bool is_init)
 		CommitTransactionCommand();
 	else
 		AbortCurrentTransaction();
+
 	return;
 }
 

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -746,6 +746,7 @@ do_check_diskquota_state_is_ready(void)
 
 	HeapTuple tup = SPI_tuptable->vals[0];
 	Datum     dat;
+	int       state;
 	bool      isnull;
 
 	dat           = SPI_getbinval(tup, tupdesc, 1, &isnull);

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -724,9 +724,8 @@ do_check_diskquota_state_is_ready(void)
 {
 	int       ret;
 	TupleDesc tupdesc;
-	bool      connected;
-	SPI_connect_wrapper(&connected);
-	ret = SPI_execute("select state from diskquota.state", true, 0);
+	bool      connected = SPI_connect_wrapper();
+	ret                 = SPI_execute("select state from diskquota.state", true, 0);
 	ereportif(ret != SPI_OK_SELECT, ERROR,
 	          (errcode(ERRCODE_INTERNAL_ERROR),
 	           errmsg("[diskquota] check diskquota state SPI_execute failed: error code %d", ret)));
@@ -1148,9 +1147,8 @@ delete_from_table_size_map(char *str)
 	                 "delete from diskquota.table_size "
 	                 "where (tableid, segid) in ( SELECT * FROM deleted_table );",
 	                 str);
-	bool connected;
-	SPI_connect_wrapper(&connected);
-	int ret = SPI_execute(delete_statement.data, false, 0);
+	bool connected = SPI_connect_wrapper();
+	int  ret       = SPI_execute(delete_statement.data, false, 0);
 	if (ret != SPI_OK_DELETE)
 		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
 		                errmsg("[diskquota] delete_from_table_size_map SPI_execute failed: error code %d", ret)));
@@ -1165,9 +1163,8 @@ insert_into_table_size_map(char *str)
 
 	initStringInfo(&insert_statement);
 	appendStringInfo(&insert_statement, "insert into diskquota.table_size values %s;", str);
-	bool connected;
-	SPI_connect_wrapper(&connected);
-	int ret = SPI_execute(insert_statement.data, false, 0);
+	bool connected = SPI_connect_wrapper();
+	int  ret       = SPI_execute(insert_statement.data, false, 0);
 	if (ret != SPI_OK_INSERT)
 		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
 		                errmsg("[diskquota] insert_into_table_size_map SPI_execute failed: error code %d", ret)));
@@ -1458,8 +1455,7 @@ do_load_quotas(void)
 	 */
 	clean_all_quota_limit();
 
-	bool connected;
-	SPI_connect_wrapper(&connected);
+	bool connected = SPI_connect_wrapper();
 	/*
 	 * read quotas from diskquota.quota_config and target table
 	 */
@@ -2286,9 +2282,8 @@ update_monitor_db_mpp(Oid dbid, FetchTableStatType action, const char *schema)
 	                 "SELECT %s.diskquota_fetch_table_stat(%d, '{%d}'::oid[]) FROM gp_dist_random('gp_id')", schema,
 	                 action, dbid);
 	/* Add current database to the monitored db cache on all segments */
-	bool connected;
-	SPI_connect_wrapper(&connected);
-	int ret = SPI_execute(sql_command.data, true, 0);
+	bool connected = SPI_connect_wrapper();
+	int  ret       = SPI_execute(sql_command.data, true, 0);
 	SPI_finish_wrapper(connected);
 	pfree(sql_command.data);
 

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -683,7 +683,7 @@ check_diskquota_state_is_ready()
 	 */
 	PG_TRY();
 	{
-		SPI_connect_my(&state);
+		SPI_connect_wrapper(&state);
 		is_ready = do_check_diskquota_state_is_ready();
 	}
 	PG_CATCH();
@@ -697,7 +697,7 @@ check_diskquota_state_is_ready()
 		RESUME_INTERRUPTS();
 	}
 	PG_END_TRY();
-	SPI_finish_my(&state);
+	SPI_finish_wrapper(&state);
 	return is_ready;
 }
 
@@ -1136,12 +1136,12 @@ delete_from_table_size_map(char *str)
 	                 "delete from diskquota.table_size "
 	                 "where (tableid, segid) in ( SELECT * FROM deleted_table );",
 	                 str);
-	SPI_connect_my(&state);
+	SPI_connect_wrapper(&state);
 	ret = SPI_execute(delete_statement.data, false, 0);
 	if (ret != SPI_OK_DELETE)
 		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
 		                errmsg("[diskquota] delete_from_table_size_map SPI_execute failed: error code %d", ret)));
-	SPI_finish_my(&state);
+	SPI_finish_wrapper(&state);
 	pfree(delete_statement.data);
 }
 
@@ -1154,12 +1154,12 @@ insert_into_table_size_map(char *str)
 
 	initStringInfo(&insert_statement);
 	appendStringInfo(&insert_statement, "insert into diskquota.table_size values %s;", str);
-	SPI_connect_my(&state);
+	SPI_connect_wrapper(&state);
 	ret = SPI_execute(insert_statement.data, false, 0);
 	if (ret != SPI_OK_INSERT)
 		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
 		                errmsg("[diskquota] insert_into_table_size_map SPI_execute failed: error code %d", ret)));
-	SPI_finish_my(&state);
+	SPI_finish_wrapper(&state);
 	pfree(insert_statement.data);
 }
 
@@ -1402,7 +1402,7 @@ load_quotas(void)
 	 */
 	PG_TRY();
 	{
-		SPI_connect_my(&state);
+		SPI_connect_wrapper(&state);
 		do_load_quotas();
 	}
 	PG_CATCH();
@@ -1416,7 +1416,7 @@ load_quotas(void)
 		RESUME_INTERRUPTS();
 	}
 	PG_END_TRY();
-	SPI_finish_my(&state);
+	SPI_finish_wrapper(&state);
 	return state.do_commit;
 }
 

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -749,7 +749,9 @@ do_check_diskquota_state_is_ready(void)
 	bool      isnull;
 
 	dat           = SPI_getbinval(tup, tupdesc, 1, &isnull);
-	bool is_ready = (isnull ? DISKQUOTA_UNKNOWN_STATE : DatumGetInt32(dat)) == DISKQUOTA_READY_STATE;
+	state         = isnull ? DISKQUOTA_UNKNOWN_STATE : DatumGetInt32(dat);
+	bool is_ready = state == DISKQUOTA_READY_STATE;
+
 	SPI_finish_wrapper(connected);
 
 	if (!is_ready && !diskquota_is_readiness_logged())

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -784,6 +784,7 @@ refresh_disk_quota_model(bool is_init)
 static void
 refresh_disk_quota_usage(bool is_init)
 {
+	bool  pushed_active_snap          = false;
 	bool  ret                         = true;
 	HTAB *local_active_table_stat_map = NULL;
 
@@ -795,6 +796,8 @@ refresh_disk_quota_usage(bool is_init)
 	PG_TRY();
 	{
 		StartTransactionCommand();
+		PushActiveSnapshot(GetTransactionSnapshot());
+		pushed_active_snap = true;
 		/*
 		 * initialization stage all the tables are active. later loop, only the
 		 * tables whose disk size changed will be treated as active
@@ -834,6 +837,7 @@ refresh_disk_quota_usage(bool is_init)
 		RESUME_INTERRUPTS();
 	}
 	PG_END_TRY();
+	if (pushed_active_snap) PopActiveSnapshot();
 	if (ret)
 		CommitTransactionCommand();
 	else

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -683,7 +683,7 @@ check_diskquota_state_is_ready()
 	 */
 	PG_TRY();
 	{
-		state    = SPI_connect_wrapper();
+		SPI_connect_wrapper(&state);
 		is_ready = do_check_diskquota_state_is_ready();
 	}
 	PG_CATCH();
@@ -1134,8 +1134,9 @@ delete_from_table_size_map(char *str)
 	                 "delete from diskquota.table_size "
 	                 "where (tableid, segid) in ( SELECT * FROM deleted_table );",
 	                 str);
-	int state = SPI_connect_wrapper();
-	int ret   = SPI_execute(delete_statement.data, false, 0);
+	int state = 0;
+	SPI_connect_wrapper(&state);
+	int ret = SPI_execute(delete_statement.data, false, 0);
 	if (ret != SPI_OK_DELETE)
 		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
 		                errmsg("[diskquota] delete_from_table_size_map SPI_execute failed: error code %d", ret)));
@@ -1150,8 +1151,9 @@ insert_into_table_size_map(char *str)
 
 	initStringInfo(&insert_statement);
 	appendStringInfo(&insert_statement, "insert into diskquota.table_size values %s;", str);
-	int state = SPI_connect_wrapper();
-	int ret   = SPI_execute(insert_statement.data, false, 0);
+	int state = 0;
+	SPI_connect_wrapper(&state);
+	int ret = SPI_execute(insert_statement.data, false, 0);
 	if (ret != SPI_OK_INSERT)
 		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
 		                errmsg("[diskquota] insert_into_table_size_map SPI_execute failed: error code %d", ret)));
@@ -1398,7 +1400,7 @@ load_quotas(void)
 	 */
 	PG_TRY();
 	{
-		state = SPI_connect_wrapper();
+		SPI_connect_wrapper(&state);
 		do_load_quotas();
 	}
 	PG_CATCH();

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -752,7 +752,7 @@ do_check_diskquota_state_is_ready(void)
 	state         = isnull ? DISKQUOTA_UNKNOWN_STATE : DatumGetInt32(dat);
 	bool is_ready = state == DISKQUOTA_READY_STATE;
 
-	SPI_finish_if_connected(connected);
+	SPI_finish_if(connected);
 
 	if (!is_ready && !diskquota_is_readiness_logged())
 	{
@@ -1152,7 +1152,7 @@ delete_from_table_size_map(char *str)
 	if (ret != SPI_OK_DELETE)
 		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
 		                errmsg("[diskquota] delete_from_table_size_map SPI_execute failed: error code %d", ret)));
-	SPI_finish_if_connected(connected);
+	SPI_finish_if(connected);
 	pfree(delete_statement.data);
 }
 
@@ -1168,7 +1168,7 @@ insert_into_table_size_map(char *str)
 	if (ret != SPI_OK_INSERT)
 		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
 		                errmsg("[diskquota] insert_into_table_size_map SPI_execute failed: error code %d", ret)));
-	SPI_finish_if_connected(connected);
+	SPI_finish_if(connected);
 	pfree(insert_statement.data);
 }
 
@@ -1537,7 +1537,7 @@ do_load_quotas(void)
 		}
 	}
 
-	SPI_finish_if_connected(connected);
+	SPI_finish_if(connected);
 }
 
 /*
@@ -2284,7 +2284,7 @@ update_monitor_db_mpp(Oid dbid, FetchTableStatType action, const char *schema)
 	/* Add current database to the monitored db cache on all segments */
 	bool connected = SPI_connect_if_not_yet();
 	int  ret       = SPI_execute(sql_command.data, true, 0);
-	SPI_finish_if_connected(connected);
+	SPI_finish_if(connected);
 	pfree(sql_command.data);
 
 	ereportif(ret != SPI_OK_SELECT, ERROR,

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -673,7 +673,7 @@ vacuum_disk_quota_model(uint32 id)
 bool
 check_diskquota_state_is_ready()
 {
-	int  state;
+	int  state    = 0;
 	bool is_ready = false;
 
 	/*
@@ -1393,7 +1393,7 @@ truncateStringInfo(StringInfo str, int nchars)
 static bool
 load_quotas(void)
 {
-	int state;
+	int state = 0;
 
 	/*
 	 * Cache Errors during SPI functions, for example a segment may be down

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -1200,7 +1200,7 @@ flush_to_table_size(void)
 				}
 			}
 			/* update the table size by delete+insert in table table_size */
-			else if (TableSizeEntryGetFlushFlag(tsentry, i)) //
+			else if (TableSizeEntryGetFlushFlag(tsentry, i))
 			{
 				appendStringInfo(&delete_statement, "%s(%u,%d)", (delete_entries_num == 0) ? " " : ", ",
 				                 tsentry->key.reloid, i);

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -724,7 +724,7 @@ do_check_diskquota_state_is_ready(void)
 {
 	int       ret;
 	TupleDesc tupdesc;
-	bool      connected = SPI_connect_wrapper();
+	bool      connected = SPI_connect_if_not_yet();
 	ret                 = SPI_execute("select state from diskquota.state", true, 0);
 	ereportif(ret != SPI_OK_SELECT, ERROR,
 	          (errcode(ERRCODE_INTERNAL_ERROR),
@@ -752,7 +752,7 @@ do_check_diskquota_state_is_ready(void)
 	state         = isnull ? DISKQUOTA_UNKNOWN_STATE : DatumGetInt32(dat);
 	bool is_ready = state == DISKQUOTA_READY_STATE;
 
-	SPI_finish_wrapper(connected);
+	SPI_finish_if_connected(connected);
 
 	if (!is_ready && !diskquota_is_readiness_logged())
 	{
@@ -1147,12 +1147,12 @@ delete_from_table_size_map(char *str)
 	                 "delete from diskquota.table_size "
 	                 "where (tableid, segid) in ( SELECT * FROM deleted_table );",
 	                 str);
-	bool connected = SPI_connect_wrapper();
+	bool connected = SPI_connect_if_not_yet();
 	int  ret       = SPI_execute(delete_statement.data, false, 0);
 	if (ret != SPI_OK_DELETE)
 		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
 		                errmsg("[diskquota] delete_from_table_size_map SPI_execute failed: error code %d", ret)));
-	SPI_finish_wrapper(connected);
+	SPI_finish_if_connected(connected);
 	pfree(delete_statement.data);
 }
 
@@ -1163,12 +1163,12 @@ insert_into_table_size_map(char *str)
 
 	initStringInfo(&insert_statement);
 	appendStringInfo(&insert_statement, "insert into diskquota.table_size values %s;", str);
-	bool connected = SPI_connect_wrapper();
+	bool connected = SPI_connect_if_not_yet();
 	int  ret       = SPI_execute(insert_statement.data, false, 0);
 	if (ret != SPI_OK_INSERT)
 		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
 		                errmsg("[diskquota] insert_into_table_size_map SPI_execute failed: error code %d", ret)));
-	SPI_finish_wrapper(connected);
+	SPI_finish_if_connected(connected);
 	pfree(insert_statement.data);
 }
 
@@ -1455,7 +1455,7 @@ do_load_quotas(void)
 	 */
 	clean_all_quota_limit();
 
-	bool connected = SPI_connect_wrapper();
+	bool connected = SPI_connect_if_not_yet();
 	/*
 	 * read quotas from diskquota.quota_config and target table
 	 */
@@ -1537,7 +1537,7 @@ do_load_quotas(void)
 		}
 	}
 
-	SPI_finish_wrapper(connected);
+	SPI_finish_if_connected(connected);
 }
 
 /*
@@ -2282,9 +2282,9 @@ update_monitor_db_mpp(Oid dbid, FetchTableStatType action, const char *schema)
 	                 "SELECT %s.diskquota_fetch_table_stat(%d, '{%d}'::oid[]) FROM gp_dist_random('gp_id')", schema,
 	                 action, dbid);
 	/* Add current database to the monitored db cache on all segments */
-	bool connected = SPI_connect_wrapper();
+	bool connected = SPI_connect_if_not_yet();
 	int  ret       = SPI_execute(sql_command.data, true, 0);
-	SPI_finish_wrapper(connected);
+	SPI_finish_if_connected(connected);
 	pfree(sql_command.data);
 
 	ereportif(ret != SPI_OK_SELECT, ERROR,

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -1161,7 +1161,7 @@ insert_into_table_size_map(char *str)
 
 	initStringInfo(&insert_statement);
 	appendStringInfo(&insert_statement, "insert into diskquota.table_size values %s;", str);
-	bool connected = 0;
+	bool connected;
 	SPI_connect_wrapper(&connected);
 	int ret = SPI_execute(insert_statement.data, false, 0);
 	if (ret != SPI_OK_INSERT)
@@ -1454,7 +1454,7 @@ do_load_quotas(void)
 	 */
 	clean_all_quota_limit();
 
-	bool connected = 0;
+	bool connected;
 	SPI_connect_wrapper(&connected);
 	/*
 	 * read quotas from diskquota.quota_config and target table
@@ -2282,7 +2282,7 @@ update_monitor_db_mpp(Oid dbid, FetchTableStatType action, const char *schema)
 	                 "SELECT %s.diskquota_fetch_table_stat(%d, '{%d}'::oid[]) FROM gp_dist_random('gp_id')", schema,
 	                 action, dbid);
 	/* Add current database to the monitored db cache on all segments */
-	bool connected = 0;
+	bool connected;
 	SPI_connect_wrapper(&connected);
 	int ret = SPI_execute(sql_command.data, true, 0);
 	SPI_finish_wrapper(connected);

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -1126,9 +1126,7 @@ calculate_table_disk_usage(bool is_init, HTAB *local_active_table_stat_map)
 static void
 delete_from_table_size_map(char *str)
 {
-	int            state;
 	StringInfoData delete_statement;
-	int            ret;
 
 	initStringInfo(&delete_statement);
 	appendStringInfo(&delete_statement,
@@ -1136,8 +1134,8 @@ delete_from_table_size_map(char *str)
 	                 "delete from diskquota.table_size "
 	                 "where (tableid, segid) in ( SELECT * FROM deleted_table );",
 	                 str);
-	state = SPI_connect_wrapper();
-	ret   = SPI_execute(delete_statement.data, false, 0);
+	int state = SPI_connect_wrapper();
+	int ret   = SPI_execute(delete_statement.data, false, 0);
 	if (ret != SPI_OK_DELETE)
 		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
 		                errmsg("[diskquota] delete_from_table_size_map SPI_execute failed: error code %d", ret)));
@@ -1148,14 +1146,12 @@ delete_from_table_size_map(char *str)
 static void
 insert_into_table_size_map(char *str)
 {
-	int            state;
 	StringInfoData insert_statement;
-	int            ret;
 
 	initStringInfo(&insert_statement);
 	appendStringInfo(&insert_statement, "insert into diskquota.table_size values %s;", str);
-	state = SPI_connect_wrapper();
-	ret   = SPI_execute(insert_statement.data, false, 0);
+	int state = SPI_connect_wrapper();
+	int ret   = SPI_execute(insert_statement.data, false, 0);
 	if (ret != SPI_OK_INSERT)
 		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
 		                errmsg("[diskquota] insert_into_table_size_map SPI_execute failed: error code %d", ret)));

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -724,8 +724,8 @@ do_check_diskquota_state_is_ready(void)
 {
 	int       ret;
 	TupleDesc tupdesc;
-	int       state = 0;
-	SPI_connect_wrapper(&state);
+	bool      connected;
+	SPI_connect_wrapper(&connected);
 	ret = SPI_execute("select state from diskquota.state", true, 0);
 	ereportif(ret != SPI_OK_SELECT, ERROR,
 	          (errcode(ERRCODE_INTERNAL_ERROR),
@@ -750,7 +750,7 @@ do_check_diskquota_state_is_ready(void)
 
 	dat           = SPI_getbinval(tup, tupdesc, 1, &isnull);
 	bool is_ready = (isnull ? DISKQUOTA_UNKNOWN_STATE : DatumGetInt32(dat)) == DISKQUOTA_READY_STATE;
-	SPI_finish_wrapper(state);
+	SPI_finish_wrapper(connected);
 
 	if (!is_ready && !diskquota_is_readiness_logged())
 	{
@@ -1144,13 +1144,13 @@ delete_from_table_size_map(char *str)
 	                 "delete from diskquota.table_size "
 	                 "where (tableid, segid) in ( SELECT * FROM deleted_table );",
 	                 str);
-	int state = 0;
-	SPI_connect_wrapper(&state);
+	bool connected;
+	SPI_connect_wrapper(&connected);
 	int ret = SPI_execute(delete_statement.data, false, 0);
 	if (ret != SPI_OK_DELETE)
 		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
 		                errmsg("[diskquota] delete_from_table_size_map SPI_execute failed: error code %d", ret)));
-	SPI_finish_wrapper(state);
+	SPI_finish_wrapper(connected);
 	pfree(delete_statement.data);
 }
 
@@ -1161,13 +1161,13 @@ insert_into_table_size_map(char *str)
 
 	initStringInfo(&insert_statement);
 	appendStringInfo(&insert_statement, "insert into diskquota.table_size values %s;", str);
-	int state = 0;
-	SPI_connect_wrapper(&state);
+	bool connected = 0;
+	SPI_connect_wrapper(&connected);
 	int ret = SPI_execute(insert_statement.data, false, 0);
 	if (ret != SPI_OK_INSERT)
 		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
 		                errmsg("[diskquota] insert_into_table_size_map SPI_execute failed: error code %d", ret)));
-	SPI_finish_wrapper(state);
+	SPI_finish_wrapper(connected);
 	pfree(insert_statement.data);
 }
 
@@ -1454,8 +1454,8 @@ do_load_quotas(void)
 	 */
 	clean_all_quota_limit();
 
-	int state = 0;
-	SPI_connect_wrapper(&state);
+	bool connected = 0;
+	SPI_connect_wrapper(&connected);
 	/*
 	 * read quotas from diskquota.quota_config and target table
 	 */
@@ -1537,7 +1537,7 @@ do_load_quotas(void)
 		}
 	}
 
-	SPI_finish_wrapper(state);
+	SPI_finish_wrapper(connected);
 }
 
 /*
@@ -2282,10 +2282,10 @@ update_monitor_db_mpp(Oid dbid, FetchTableStatType action, const char *schema)
 	                 "SELECT %s.diskquota_fetch_table_stat(%d, '{%d}'::oid[]) FROM gp_dist_random('gp_id')", schema,
 	                 action, dbid);
 	/* Add current database to the monitored db cache on all segments */
-	int state = 0;
-	SPI_connect_wrapper(&state);
+	bool connected = 0;
+	SPI_connect_wrapper(&connected);
 	int ret = SPI_execute(sql_command.data, true, 0);
-	SPI_finish_wrapper(state);
+	SPI_finish_wrapper(connected);
 	pfree(sql_command.data);
 
 	ereportif(ret != SPI_OK_SELECT, ERROR,

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -692,7 +692,7 @@ check_diskquota_state_is_ready()
 		HOLD_INTERRUPTS();
 		EmitErrorReport();
 		FlushErrorState();
-		state |= is_abort;
+		state |= IS_ABORT;
 		/* Now we can allow interrupts again */
 		RESUME_INTERRUPTS();
 	}
@@ -1407,13 +1407,13 @@ load_quotas(void)
 		HOLD_INTERRUPTS();
 		EmitErrorReport();
 		FlushErrorState();
-		state |= is_abort;
+		state |= IS_ABORT;
 		/* Now we can allow interrupts again */
 		RESUME_INTERRUPTS();
 	}
 	PG_END_TRY();
 	SPI_finish_wrapper(state);
-	return !(state & is_abort);
+	return !(state & IS_ABORT);
 }
 
 /*


### PR DESCRIPTION
Use short-lived SPI contexts

diskquota uses long-lived SPI contexts in most places: at the beginning it
calls the SPI_connect function, which creates an SPI context and switches to
its use, then it does a lot of work, including SPI_execute, and only at the
very end it calls the SPI_finish function, which clears the SPI context. This
usage architecture is incorrect and can lead to memory leaks while the SPI
context is alive, because the SPI_execute function, for example, allocates
memory in it for parsing a SQL query. Correct use of SPI involves opening and
closing the SPI as close as possible, so that the SPI context is as short-lived
as possible. This patch adds new wrappers for connecting and disconnecting
functions from SPI and their usage, and moves the connection to SPI into
functions closer to making requests over SPI.

---
It is easier to view the changes with the "Hide whitespace" option enabled.