### PR TITLE
ADBDEV-6616: Fix potentially clobbered variables in PG_TRY/PG_CATCH blocks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ if (APPLE)
     set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -bundle_loader ${PG_BIN_DIR}/postgres")
 endif()
 # set c and ld flags for all projects
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${PG_C_FLAGS}")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wclobbered ${PG_C_FLAGS}")
 
 # generate version
 if(NOT DEFINED DISKQUOTA_VERSION)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ if (APPLE)
     set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -bundle_loader ${PG_BIN_DIR}/postgres")
 endif()
 # set c and ld flags for all projects
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wclobbered ${PG_C_FLAGS}")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror=clobbered ${PG_C_FLAGS}")
 
 # generate version
 if(NOT DEFINED DISKQUOTA_VERSION)

--- a/src/diskquota.c
+++ b/src/diskquota.c
@@ -958,10 +958,10 @@ disk_quota_launcher_main(Datum main_arg)
 static void
 create_monitor_db_table(void)
 {
-	const char *sql;
-	bool        connected_in_this_function = false;
-	bool        pushed_active_snap         = false;
-	bool        ret                        = true;
+	const char   *sql;
+	volatile bool connected_in_this_function = false;
+	volatile bool pushed_active_snap         = false;
+	volatile bool ret                        = true;
 
 	/*
 	 * Create function diskquota.diskquota_fetch_table_stat in launcher
@@ -1167,9 +1167,9 @@ process_extension_ddl_message()
 static void
 do_process_extension_ddl_message(MessageResult *code, ExtensionDDLMessage local_extension_ddl_message)
 {
-	int  old_num_db         = num_db;
-	bool pushed_active_snap = false;
-	bool ret                = true;
+	int           old_num_db         = num_db;
+	volatile bool pushed_active_snap = false;
+	volatile bool ret                = true;
 
 	StartTransactionCommand();
 

--- a/src/diskquota_utility.c
+++ b/src/diskquota_utility.c
@@ -1430,9 +1430,9 @@ relation_size_local(PG_FUNCTION_ARGS)
 Relation
 diskquota_relation_open(Oid relid)
 {
-	Relation rel;
-	bool     success_open               = false;
-	int32    SavedInterruptHoldoffCount = InterruptHoldoffCount;
+	volatile Relation rel;
+	volatile bool     success_open               = false;
+	int32             SavedInterruptHoldoffCount = InterruptHoldoffCount;
 
 	PG_TRY();
 	{

--- a/src/enforcement.c
+++ b/src/enforcement.c
@@ -44,7 +44,7 @@ init_disk_quota_enforcement(void)
 static bool
 quota_check_ExecCheckRTPerms(List *rangeTable, bool ereport_on_violation)
 {
-	ListCell *l;
+	ListCell *volatile l;
 
 	foreach (l, rangeTable)
 	{


### PR DESCRIPTION
Fix potentially clobbered variables in PG_TRY/PG_CATCH blocks

Some local variables may have an undefined value after longjmp, which can lead
to undefined behavior.

This patch adds volatile to such variables based on a compiler warning. Fix a
potential memory leak related to creating a hashmap inside a try/catch block.
Add a compiler flag for throwing error related to clobbering variables.