### PR TITLE
ADBDEV-6443: Refactor diskquota local hashmap with active tables

### DIFF
--- a/src/diskquota.h
+++ b/src/diskquota.h
@@ -291,7 +291,7 @@ extern int   diskquota_hashmap_overflow_report_timeout;
 extern int      SEGCOUNT;
 extern int      worker_spi_get_extension_version(int *major, int *minor);
 extern void     truncateStringInfo(StringInfo str, int nchars);
-extern List    *get_rel_oid_list(bool is_init);
+extern List    *get_rel_oid_list(void);
 extern int64    calculate_relation_size_all_forks(RelFileNodeBackend *rnode, char relstorage, Oid relam);
 extern Relation diskquota_relation_open(Oid relid);
 extern bool     get_rel_name_namespace(Oid relid, Oid *nsOid, char *relname);

--- a/src/diskquota.h
+++ b/src/diskquota.h
@@ -17,6 +17,7 @@
 #include "postgres.h"
 #include "port/atomics.h"
 
+#include "access/htup.h"
 #include "catalog/pg_class.h"
 #include "lib/ilist.h"
 #include "lib/stringinfo.h"
@@ -45,6 +46,8 @@
 #define AVG_QUOTA_MAP_ENTRIES (diskquota_max_quota_probes / diskquota_max_monitored_databases)
 /* max number of QuotaInfoEntry in quota_info_map */
 #define MAX_QUOTA_MAP_ENTRIES (AVG_QUOTA_MAP_ENTRIES < 1024 ? 1024 : AVG_QUOTA_MAP_ENTRIES)
+
+#define DatumGetArrayTypePwrapper(X) ((X) ? DatumGetArrayTypeP(X) : NULL)
 
 typedef enum
 {
@@ -321,4 +324,5 @@ extern HASHACTION check_hash_fullness(HTAB *hashp, int max_size, const char *war
                                       TimestampTz *last_overflow_report);
 bool              SPI_connect_if_not_yet(void);
 void              SPI_finish_if(bool connected_in_this_function);
+Datum SPI_getbinval_wrapper(HeapTuple tuple, TupleDesc tupdesc, const char *fname, bool allow_null, Oid typeid);
 #endif

--- a/src/diskquota.h
+++ b/src/diskquota.h
@@ -17,7 +17,6 @@
 #include "postgres.h"
 #include "port/atomics.h"
 
-#include "access/htup.h"
 #include "catalog/pg_class.h"
 #include "lib/ilist.h"
 #include "lib/stringinfo.h"
@@ -322,5 +321,4 @@ extern HASHACTION check_hash_fullness(HTAB *hashp, int max_size, const char *war
                                       TimestampTz *last_overflow_report);
 bool              SPI_connect_if_not_yet(void);
 void              SPI_finish_if(bool connected_in_this_function);
-Datum SPI_getbinval_wrapper(HeapTuple tuple, TupleDesc tupdesc, const char *fname, bool allow_null, Oid typeid);
 #endif

--- a/src/diskquota.h
+++ b/src/diskquota.h
@@ -47,8 +47,6 @@
 /* max number of QuotaInfoEntry in quota_info_map */
 #define MAX_QUOTA_MAP_ENTRIES (AVG_QUOTA_MAP_ENTRIES < 1024 ? 1024 : AVG_QUOTA_MAP_ENTRIES)
 
-#define DatumGetArrayTypePwrapper(X) ((X) ? DatumGetArrayTypeP(X) : NULL)
-
 typedef enum
 {
 	DISKQUOTA_TAG_HASH = 0,

--- a/src/diskquota_utility.c
+++ b/src/diskquota_utility.c
@@ -1714,18 +1714,3 @@ SPI_finish_if(bool connected_in_calling_function)
 	          (errcode(ERRCODE_INTERNAL_ERROR), errmsg("[diskquota] SPI_finish failed"),
 	           errdetail("%s", SPI_result_code_string(rc))));
 }
-
-Datum
-SPI_getbinval_wrapper(HeapTuple tuple, TupleDesc tupdesc, const char *fname, bool allow_null, Oid typeid)
-{
-	bool  isnull;
-	Datum datum;
-	int   fnumber = SPI_fnumber(tupdesc, fname);
-	if (SPI_gettypeid(tupdesc, fnumber) != typeid)
-		ereport(ERROR, (errcode(ERRCODE_MOST_SPECIFIC_TYPE_MISMATCH),
-		                errmsg("type of column \"%s\" must be \"%i\"", fname, typeid)));
-	datum = SPI_getbinval(tuple, tupdesc, fnumber, &isnull);
-	if (isnull && !allow_null)
-		ereport(ERROR, (errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED), errmsg("column \"%s\" must not be null", fname)));
-	return datum;
-}

--- a/src/diskquota_utility.c
+++ b/src/diskquota_utility.c
@@ -1714,3 +1714,18 @@ SPI_finish_if(bool connected_in_calling_function)
 	          (errcode(ERRCODE_INTERNAL_ERROR), errmsg("[diskquota] SPI_finish failed"),
 	           errdetail("%s", SPI_result_code_string(rc))));
 }
+
+Datum
+SPI_getbinval_wrapper(HeapTuple tuple, TupleDesc tupdesc, const char *fname, bool allow_null, Oid typeid)
+{
+	bool  isnull;
+	Datum datum;
+	int   fnumber = SPI_fnumber(tupdesc, fname);
+	if (SPI_gettypeid(tupdesc, fnumber) != typeid)
+		ereport(ERROR, (errcode(ERRCODE_MOST_SPECIFIC_TYPE_MISMATCH),
+		                errmsg("type of column \"%s\" must be \"%i\"", fname, typeid)));
+	datum = SPI_getbinval(tuple, tupdesc, fnumber, &isnull);
+	if (isnull && !allow_null)
+		ereport(ERROR, (errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED), errmsg("column \"%s\" must not be null", fname)));
+	return datum;
+}

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -1082,7 +1082,7 @@ pull_active_table_size_from_seg(HTAB *local_table_stats_map)
 	int            j;
 
 	initStringInfo(&sql_command);
-	appendStringInfo(&sql_command, "select * from diskquota.diskquota_fetch_table_stat(1, '{%s}'::oid[])",
+	appendStringInfo(&sql_command, "select * from diskquota.diskquota_fetch_table_stat(1, ARRAY[%s]::oid[])",
 	                 active_oids.data);
 	CdbDispatchCommand(sql_command.data, DF_NONE, &cdb_pgresults);
 	pfree(sql_command.data);

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -35,7 +35,6 @@
 #include "storage/smgr.h"
 #include "utils/faultinjector.h"
 #include "utils/lsyscache.h"
-#include "utils/memutils.h"
 #include "utils/syscache.h"
 #include "utils/inval.h"
 

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -970,8 +970,8 @@ load_table_size(StringInfoData *active_oids)
 		{
 			HeapTuple val   = SPI_tuptable->vals[row];
 			Oid       oid   = DatumGetObjectId(SPI_getbinval_wrapper(val, tupdesc, tableid_num, false));
-			int64     size  = DatumGetObjectId(SPI_getbinval_wrapper(val, tupdesc, size_num, false));
-			int16     segid = DatumGetObjectId(SPI_getbinval_wrapper(val, tupdesc, segid_num, false));
+			int64     size  = DatumGetInt64(SPI_getbinval_wrapper(val, tupdesc, size_num, false));
+			int16     segid = DatumGetInt16(SPI_getbinval_wrapper(val, tupdesc, segid_num, false));
 
 			update_active_table_size(oid, size, segid);
 

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -1029,12 +1029,6 @@ pull_active_table_oid_from_seg(StringInfoData *active_oids)
 	hash_destroy(oid_map);
 }
 
-typedef struct OidSize
-{
-	Oid   oid;
-	int64 size;
-} OidSize;
-
 /*
  * Get active table list from all the segments.
  * Since when loading data, there is case where only subset for
@@ -1061,14 +1055,18 @@ pull_active_table_size_from_seg(const char *active_oids)
 		ereport(ERROR, (errmsg("[diskquota] there is no active segment, SEGCOUNT is %d", SEGCOUNT)));
 	}
 
-	OidSize *entry;
-	HASHCTL  ctl = {
-	         .keysize   = sizeof(Oid),
-	         .entrysize = sizeof(OidSize),
-	         .hcxt      = CurrentMemoryContext,
-    };
-	HTAB *size_map = diskquota_hash_create("local active table map with relfilenode info", 1024, &ctl,
-	                                       HASH_ELEM | HASH_CONTEXT, DISKQUOTA_OID_HASH);
+	struct
+	{
+		Oid   oid;
+		int64 size;
+	} * oid_size;
+	HASHCTL ctl = {
+	        .keysize   = sizeof(Oid),
+	        .entrysize = sizeof(*oid_size),
+	        .hcxt      = CurrentMemoryContext,
+	};
+	HTAB *oid_size_map = diskquota_hash_create("local active table map with size info", 1024, &ctl,
+	                                           HASH_ELEM | HASH_CONTEXT, DISKQUOTA_OID_HASH);
 
 	for (int i = 0; i < cdb_pgresults.numResults; i++)
 	{
@@ -1084,14 +1082,14 @@ pull_active_table_size_from_seg(const char *active_oids)
 		for (int j = 0; j < PQntuples(pgresult); j++)
 		{
 			bool  found;
-			Oid   tableid = atooid(PQgetvalue(pgresult, j, 0));
-			int64 size    = atoll(PQgetvalue(pgresult, j, 1));
-			int16 segid   = atoi(PQgetvalue(pgresult, j, 2));
+			Oid   oid   = atooid(PQgetvalue(pgresult, j, 0));
+			int64 size  = atoll(PQgetvalue(pgresult, j, 1));
+			int16 segid = atoi(PQgetvalue(pgresult, j, 2));
 
-			update_active_table_size(tableid, size, segid, NULL);
-			entry = hash_search(size_map, &tableid, HASH_ENTER, &found);
+			update_active_table_size(oid, size, segid, NULL);
+			oid_size = hash_search(oid_size_map, &oid, HASH_ENTER, &found);
 			/* tablesize for master is the sum of tablesize of master and all segments */
-			entry->size = (found ? entry->size : 0) + size;
+			oid_size->size = (found ? oid_size->size : 0) + size;
 		}
 		// update_active_table_size(tableid0, size0, -1, NULL);
 	}
@@ -1099,12 +1097,12 @@ pull_active_table_size_from_seg(const char *active_oids)
 
 	HASH_SEQ_STATUS iter;
 
-	hash_seq_init(&iter, size_map);
+	hash_seq_init(&iter, oid_size_map);
 
-	while ((entry = hash_seq_search(&iter)) != NULL)
+	while ((oid_size = hash_seq_search(&iter)) != NULL)
 	{
-		update_active_table_size(entry->oid, entry->size, -1, NULL);
+		update_active_table_size(oid_size->oid, oid_size->size, -1, NULL);
 	}
 
-	hash_destroy(size_map);
+	hash_destroy(oid_size_map);
 }

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -924,10 +924,8 @@ load_table_size(StringInfoData *active_oids)
 	int        i;
 	SPIPlanPtr plan;
 	Portal     portal;
-
-	static const char *sql = "select tableid, size, segid from diskquota.table_size";
-
-	bool connected_in_this_function = SPI_connect_if_not_yet();
+	char      *sql                        = "select tableid, size, segid from diskquota.table_size";
+	bool       connected_in_this_function = SPI_connect_if_not_yet();
 
 	if ((plan = SPI_prepare(sql, 0, NULL)) == NULL)
 		ereport(ERROR, (errmsg("[diskquota] SPI_prepare(\"%s\") failed", sql)));

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -957,15 +957,20 @@ load_table_size(StringInfoData *active_oids)
 	if ((portal = SPI_cursor_open(NULL, plan, NULL, NULL, true)) == NULL)
 		ereport(ERROR, (errmsg("[diskquota] SPI_cursor_open(\"%s\") failed", sql)));
 
-	do
+	SPI_cursor_fetch(portal, true, 10000);
+
+	if (SPI_tuptable == NULL)
 	{
-		SPI_cursor_fetch(portal, true, 10000);
+		ereport(ERROR, (errmsg("[diskquota] load_table_size SPI_cursor_fetch failed")));
+	}
 
-		TupleDesc tupdesc     = SPI_tuptable->tupdesc;
-		int       tableid_num = SPI_fnumber_wrapper(tupdesc, "tableid", OIDOID);
-		int       size_num    = SPI_fnumber_wrapper(tupdesc, "size", INT8OID);
-		int       segid_num   = SPI_fnumber_wrapper(tupdesc, "segid", INT2OID);
+	TupleDesc tupdesc     = SPI_tuptable->tupdesc;
+	int       tableid_num = SPI_fnumber_wrapper(tupdesc, "tableid", OIDOID);
+	int       size_num    = SPI_fnumber_wrapper(tupdesc, "size", INT8OID);
+	int       segid_num   = SPI_fnumber_wrapper(tupdesc, "segid", INT2OID);
 
+	while (SPI_processed > 0)
+	{
 		for (uint64 row = 0; row < SPI_processed; row++)
 		{
 			HeapTuple val   = SPI_tuptable->vals[row];
@@ -982,8 +987,10 @@ load_table_size(StringInfoData *active_oids)
 			}
 		}
 		SPI_freetuptable(SPI_tuptable);
-	} while (SPI_processed);
+		SPI_cursor_fetch(portal, true, 10000);
+	}
 
+	SPI_freetuptable(SPI_tuptable);
 	SPI_cursor_close(portal);
 	SPI_freeplan(plan);
 	SPI_finish_if(connected_in_this_function);

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -90,7 +90,7 @@ static HTAB *get_active_tables_stats(ArrayType *array);
 static HTAB *get_active_tables_oid(void);
 static void  pull_active_table_oid_from_seg(StringInfoData *active_oids);
 static void  pull_active_table_size_from_seg(const char *active_oids);
-static void  convert_map_to_string(HTAB *oid_map, StringInfoData *active_oids);
+static void  convert_map_to_string(HTAB *map, StringInfoData *buf);
 static void  load_table_size(StringInfoData *active_oids);
 static void  report_active_table_helper(const RelFileNodeBackend *relFileNode);
 static void  remove_from_active_table_map(const RelFileNodeBackend *relFileNode);
@@ -966,17 +966,17 @@ load_table_size(StringInfoData *active_oids)
  * of function diskquota_fetch_table_stat.
  */
 static void
-convert_map_to_string(HTAB *oid_map, StringInfoData *active_oids)
+convert_map_to_string(HTAB *map, StringInfoData *buf)
 {
 	HASH_SEQ_STATUS iter;
 	Oid            *oid;
 
-	hash_seq_init(&iter, oid_map);
+	hash_seq_init(&iter, map);
 
 	while ((oid = hash_seq_search(&iter)) != NULL)
 	{
-		if (active_oids->len > 0) appendStringInfoString(active_oids, ",");
-		appendStringInfo(active_oids, "%d", *oid);
+		if (buf->len > 0) appendStringInfoString(buf, ",");
+		appendStringInfo(buf, "%d", *oid);
 	}
 }
 
@@ -990,9 +990,10 @@ static void
 pull_active_table_oid_from_seg(StringInfoData *active_oids)
 {
 	CdbPgResults cdb_pgresults = {NULL, 0};
-	HASHCTL      ctl           = {.keysize = sizeof(Oid), .entrysize = sizeof(Oid), .hcxt = CurrentMemoryContext};
-	HTAB        *oid_map       = diskquota_hash_create("local active table map with relfilenode info", 1024, &ctl,
-	                                                   HASH_ELEM | HASH_CONTEXT, DISKQUOTA_OID_HASH);
+
+	HASHCTL ctl = {.keysize = sizeof(Oid), .entrysize = sizeof(Oid), .hcxt = CurrentMemoryContext};
+	HTAB   *map = diskquota_hash_create("local active table map with relfilenode info", 1024, &ctl,
+	                                    HASH_ELEM | HASH_CONTEXT, DISKQUOTA_OID_HASH);
 
 	/* first get all oid of tables which are active table on any segment */
 	static const char *sql = "select * from diskquota.diskquota_fetch_table_stat(0, ARRAY[]::oid[])";
@@ -1014,13 +1015,13 @@ pull_active_table_oid_from_seg(StringInfoData *active_oids)
 		for (int row = 0; row < PQntuples(pgresult); row++)
 		{
 			Oid oid = atooid(PQgetvalue(pgresult, row, PQfnumber(pgresult, "\"TABLE_OID\"")));
-			(void)hash_search(oid_map, &oid, HASH_ENTER, NULL);
+			(void)hash_search(map, &oid, HASH_ENTER, NULL);
 		}
 	}
 	cdbdisp_clearCdbPgResults(&cdb_pgresults);
 
-	convert_map_to_string(oid_map, active_oids);
-	hash_destroy(oid_map);
+	convert_map_to_string(map, active_oids);
+	hash_destroy(map);
 }
 
 /*

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -1055,7 +1055,9 @@ pull_active_list_from_seg(void)
 	}
 	cdbdisp_clearCdbPgResults(&cdb_pgresults);
 
+	MemoryContext  oldContext  = MemoryContextSwitchTo(CurTransactionContext);
 	StringInfoData active_oids = convert_map_to_string(local_active_table_oid_map);
+	MemoryContextSwitchTo(oldContext);
 	hash_destroy(local_active_table_oid_map);
 
 	return active_oids;

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -89,7 +89,7 @@ static HTAB *get_active_tables_stats(ArrayType *array);
 static HTAB *get_active_tables_oid(void);
 static void  pull_active_list_from_seg(StringInfoData *active_oids);
 static void  pull_active_table_size_from_seg(const char *active_oids);
-static void  convert_map_to_string(HTAB *map, StringInfoData *buf);
+static void  convert_map_to_string(HTAB *local_active_table_oid_maps, StringInfoData *buf);
 static void  load_table_size(StringInfoData *active_oids);
 static void  report_active_table_helper(const RelFileNodeBackend *relFileNode);
 static void  remove_from_active_table_map(const RelFileNodeBackend *relFileNode);
@@ -1005,19 +1005,19 @@ load_table_size(StringInfoData *active_oids)
  * of function diskquota_fetch_table_stat.
  */
 static void
-convert_map_to_string(HTAB *map, StringInfoData *buf)
+convert_map_to_string(HTAB *local_active_table_oid_maps, StringInfoData *active_oids)
 {
 	HASH_SEQ_STATUS iter;
 	Oid            *oid;
 
-	hash_seq_init(&iter, map);
+	hash_seq_init(&iter, local_active_table_oid_maps);
 
-	Assert(buf->len == 0);
+	Assert(active_oids->len == 0);
 
 	while ((oid = hash_seq_search(&iter)) != NULL)
 	{
-		if (buf->len > 0) appendStringInfoString(buf, ",");
-		appendStringInfo(buf, "%d", *oid);
+		if (active_oids->len > 0) appendStringInfoString(active_oids, ",");
+		appendStringInfo(active_oids, "%d", *oid);
 	}
 }
 

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -88,7 +88,7 @@ static void object_access_hook_QuotaStmt(ObjectAccessType access, Oid classId, O
 
 static HTAB *get_active_tables_stats(ArrayType *array);
 static HTAB *get_active_tables_oid(void);
-static void  pull_active_list_from_seg(StringInfoData *active_oids);
+static void  pull_active_table_oid_from_seg(StringInfoData *active_oids);
 static void  pull_active_table_size_from_seg(HTAB *local_table_stats_map, const char *active_oids);
 static void  convert_map_to_string(HTAB *oid_map, StringInfoData *active_oids);
 static void  load_table_size(StringInfoData *active_oids);
@@ -375,7 +375,7 @@ gp_fetch_active_tables(StringInfoData *active_oids, HTAB *local_table_stats_map)
 	else
 	{
 		/* step 1: fetch active oids from all the segments */
-		pull_active_list_from_seg(active_oids);
+		pull_active_table_oid_from_seg(active_oids);
 
 		ereport(DEBUG1,
 		        (errcode(ERRCODE_INTERNAL_ERROR), errmsg("[diskquota] active_old_list = %s", active_oids->data)));
@@ -993,7 +993,7 @@ convert_map_to_string(HTAB *oid_map, StringInfoData *active_oids)
  * the table size on the fly.
  */
 static void
-pull_active_list_from_seg(StringInfoData *active_oids)
+pull_active_table_oid_from_seg(StringInfoData *active_oids)
 {
 	CdbPgResults cdb_pgresults = {NULL, 0};
 	HASHCTL      ctl           = {.keysize = sizeof(Oid), .entrysize = sizeof(Oid), .hcxt = CurrentMemoryContext};

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -973,10 +973,10 @@ load_table_size(StringInfoData *active_oids)
 	{
 		for (uint64 row = 0; row < SPI_processed; row++)
 		{
-			HeapTuple val   = SPI_tuptable->vals[row];
-			Oid       oid   = DatumGetObjectId(SPI_getbinval_wrapper(val, tupdesc, tableid_num, false));
-			int64     size  = DatumGetInt64(SPI_getbinval_wrapper(val, tupdesc, size_num, false));
-			int16     segid = DatumGetInt16(SPI_getbinval_wrapper(val, tupdesc, segid_num, false));
+			HeapTuple tup   = SPI_tuptable->vals[row];
+			Oid       oid   = DatumGetObjectId(SPI_getbinval_wrapper(tup, tupdesc, tableid_num, false));
+			int64     size  = DatumGetInt64(SPI_getbinval_wrapper(tup, tupdesc, size_num, false));
+			int16     segid = DatumGetInt16(SPI_getbinval_wrapper(tup, tupdesc, segid_num, false));
 
 			update_active_table_size(oid, size, segid);
 

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -970,6 +970,8 @@ load_table_size(StringInfoData *active_oids)
 	int size_num    = SPI_fnumber_wrapper(tupdesc, "size", INT8OID);
 	int segid_num   = SPI_fnumber_wrapper(tupdesc, "segid", INT2OID);
 
+	Assert(active_oids->len == 0);
+
 	while (SPI_processed > 0)
 	{
 		for (i = 0; i < SPI_processed; i++)
@@ -1009,6 +1011,8 @@ convert_map_to_string(HTAB *map, StringInfoData *buf)
 	Oid            *oid;
 
 	hash_seq_init(&iter, map);
+
+	Assert(buf->len == 0);
 
 	while ((oid = hash_seq_search(&iter)) != NULL)
 	{

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -1054,13 +1054,13 @@ pull_active_table_size_from_seg(const char *active_oids)
 		Oid   oid;
 		int64 size;
 	} * oid_size;
-	HASHCTL ctl          = {.keysize = sizeof(Oid), .entrysize = sizeof(*oid_size), .hcxt = CurrentMemoryContext};
-	HTAB   *oid_size_map = diskquota_hash_create("local active table map with size info", 1024, &ctl,
-	                                             HASH_ELEM | HASH_CONTEXT, DISKQUOTA_OID_HASH);
+	HASHCTL ctl = {.keysize = sizeof(Oid), .entrysize = sizeof(*oid_size), .hcxt = CurrentMemoryContext};
+	HTAB   *map = diskquota_hash_create("local active table map with size info", 1024, &ctl, HASH_ELEM | HASH_CONTEXT,
+	                                    DISKQUOTA_OID_HASH);
 
-	for (int i = 0; i < cdb_pgresults.numResults; i++)
+	for (int segid = 0; segid < cdb_pgresults.numResults; segid++)
 	{
-		PGresult *pgresult = cdb_pgresults.pg_results[i];
+		PGresult *pgresult = cdb_pgresults.pg_results[segid];
 
 		if (PQresultStatus(pgresult) != PGRES_TUPLES_OK)
 		{
@@ -1072,12 +1072,11 @@ pull_active_table_size_from_seg(const char *active_oids)
 		for (int row = 0; row < PQntuples(pgresult); row++)
 		{
 			bool  found;
-			Oid   oid   = atooid(PQgetvalue(pgresult, row, 0));
-			int64 size  = atoll(PQgetvalue(pgresult, row, 1));
-			int16 segid = atoi(PQgetvalue(pgresult, row, 2));
+			Oid   oid  = atooid(PQgetvalue(pgresult, row, 0));
+			int64 size = atoll(PQgetvalue(pgresult, row, 1));
 
 			update_active_table_size(oid, size, segid);
-			oid_size = hash_search(oid_size_map, &oid, HASH_ENTER, &found);
+			oid_size = hash_search(map, &oid, HASH_ENTER, &found);
 			/* tablesize for master is the sum of tablesize of master and all segments */
 			oid_size->size = (found ? oid_size->size : 0) + size;
 		}
@@ -1086,12 +1085,12 @@ pull_active_table_size_from_seg(const char *active_oids)
 
 	HASH_SEQ_STATUS iter;
 
-	hash_seq_init(&iter, oid_size_map);
+	hash_seq_init(&iter, map);
 
 	while ((oid_size = hash_seq_search(&iter)) != NULL)
 	{
 		update_active_table_size(oid_size->oid, oid_size->size, -1);
 	}
 
-	hash_destroy(oid_size_map);
+	hash_destroy(map);
 }

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -1048,7 +1048,7 @@ pull_active_list_from_seg(StringInfoData *active_oids)
 	Assert(active_oids->len == 0);
 
 	/*
-	 * Convert a hash map with oids into a string array
+	 * Convert a hash map with oids into a string array.
 	 * This is used to prepare the second array parameter
 	 * of function diskquota_fetch_table_stat.
 	 */

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -913,6 +913,30 @@ get_active_tables_oid(void)
 	return local_active_table_stats_map;
 }
 
+static int
+SPI_fnumber_wrapper(TupleDesc tupdesc, const char *fname, Oid typeid)
+{
+	int fnumber = SPI_fnumber(tupdesc, fname);
+
+	if (SPI_gettypeid(tupdesc, fnumber) != typeid)
+		ereport(ERROR, (errcode(ERRCODE_MOST_SPECIFIC_TYPE_MISMATCH),
+		                errmsg("type of column \"%s\" must be \"%d\"", fname, typeid)));
+
+	return fnumber;
+}
+
+static Datum
+SPI_getbinval_wrapper(HeapTuple tuple, TupleDesc tupdesc, int fnumber, bool allow_null)
+{
+	bool  isnull;
+	Datum datum = SPI_getbinval(tuple, tupdesc, fnumber, &isnull);
+
+	if (isnull && !allow_null)
+		ereport(ERROR, (errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED), errmsg("column %d must not be null", fnumber)));
+
+	return datum;
+}
+
 /*
  * Load table size info from diskquota.table_size table.
  * This is called when system startup, disk quota rejectmap
@@ -936,13 +960,18 @@ load_table_size(StringInfoData *active_oids)
 	do
 	{
 		SPI_cursor_fetch(portal, true, 10000);
+
+		TupleDesc tupdesc     = SPI_tuptable->tupdesc;
+		int       tableid_num = SPI_fnumber_wrapper(tupdesc, "tableid", OIDOID);
+		int       size_num    = SPI_fnumber_wrapper(tupdesc, "size", INT8OID);
+		int       segid_num   = SPI_fnumber_wrapper(tupdesc, "segid", INT2OID);
+
 		for (uint64 row = 0; row < SPI_processed; row++)
 		{
-			HeapTuple val     = SPI_tuptable->vals[row];
-			TupleDesc tupdesc = SPI_tuptable->tupdesc;
-			Oid       oid     = DatumGetObjectId(SPI_getbinval_wrapper(val, tupdesc, "tableid", false, OIDOID));
-			int64     size    = DatumGetObjectId(SPI_getbinval_wrapper(val, tupdesc, "size", false, INT8OID));
-			int16     segid   = DatumGetObjectId(SPI_getbinval_wrapper(val, tupdesc, "segid", false, INT2OID));
+			HeapTuple val   = SPI_tuptable->vals[row];
+			Oid       oid   = DatumGetObjectId(SPI_getbinval_wrapper(val, tupdesc, tableid_num, false));
+			int64     size  = DatumGetObjectId(SPI_getbinval_wrapper(val, tupdesc, size_num, false));
+			int16     segid = DatumGetObjectId(SPI_getbinval_wrapper(val, tupdesc, segid_num, false));
 
 			update_active_table_size(oid, size, segid);
 

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -1054,13 +1054,9 @@ pull_active_table_size_from_seg(const char *active_oids)
 		Oid   oid;
 		int64 size;
 	} * oid_size;
-	HASHCTL ctl = {
-	        .keysize   = sizeof(Oid),
-	        .entrysize = sizeof(*oid_size),
-	        .hcxt      = CurrentMemoryContext,
-	};
-	HTAB *oid_size_map = diskquota_hash_create("local active table map with size info", 1024, &ctl,
-	                                           HASH_ELEM | HASH_CONTEXT, DISKQUOTA_OID_HASH);
+	HASHCTL ctl          = {.keysize = sizeof(Oid), .entrysize = sizeof(*oid_size), .hcxt = CurrentMemoryContext};
+	HTAB   *oid_size_map = diskquota_hash_create("local active table map with size info", 1024, &ctl,
+	                                             HASH_ELEM | HASH_CONTEXT, DISKQUOTA_OID_HASH);
 
 	for (int i = 0; i < cdb_pgresults.numResults; i++)
 	{

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -89,10 +89,10 @@ static void object_access_hook_QuotaStmt(ObjectAccessType access, Oid classId, O
 static HTAB *get_active_tables_stats(ArrayType *array);
 static HTAB *get_active_tables_oid(void);
 
-static StringInfoData pull_active_list_from_seg(void);
-static StringInfoData pull_active_table_size_from_seg(HTAB *local_table_stats_map);
-static StringInfoData convert_map_to_string(HTAB *active_list);
-static StringInfoData load_table_size(void);
+static void pull_active_list_from_seg(StringInfoData *active_oids);
+static void pull_active_table_size_from_seg(StringInfoData *active_oids, HTAB *local_table_stats_map);
+static void convert_map_to_string(StringInfoData *active_oids, HTAB *active_list);
+static void load_table_size(StringInfoData *active_oids);
 
 static void report_active_table_helper(const RelFileNodeBackend *relFileNode);
 static void remove_from_active_table_map(const RelFileNodeBackend *relFileNode);
@@ -365,8 +365,8 @@ remove_from_active_table_map(const RelFileNodeBackend *relFileNode)
  * And aggregate the table size on each segment
  * to get the real table size at cluster level.
  */
-StringInfoData
-gp_fetch_active_tables(HTAB *local_active_table_stat_map)
+void
+gp_fetch_active_tables(StringInfoData *active_oids, HTAB *local_active_table_stat_map)
 {
 	HASHCTL ctl;
 
@@ -379,10 +379,19 @@ gp_fetch_active_tables(HTAB *local_active_table_stat_map)
 
 	if (local_active_table_stat_map == NULL)
 	{
-		return load_table_size();
+		load_table_size(active_oids);
 	}
+	else
+	{
+		/* step 1: fetch active oids from all the segments */
+		pull_active_list_from_seg(active_oids);
 
-	return pull_active_table_size_from_seg(local_active_table_stat_map);
+		ereport(DEBUG1,
+		        (errcode(ERRCODE_INTERNAL_ERROR), errmsg("[diskquota] active_old_list = %s", active_oids->data)));
+
+		/* step 2: fetch active table sizes based on active oids */
+		pull_active_table_size_from_seg(active_oids, local_active_table_stat_map);
+	}
 }
 
 /*
@@ -918,8 +927,8 @@ get_active_tables_oid(void)
  * This is called when system startup, disk quota rejectmap
  * and other shared memory will be warmed up by table_size table.
  */
-static StringInfoData
-load_table_size(void)
+static void
+load_table_size(StringInfoData *active_oids)
 {
 	SPIPlanPtr plan;
 	Portal     portal;
@@ -927,13 +936,10 @@ load_table_size(void)
 	bool       typbyval;
 	char       typalign;
 
-	StringInfoData     active_oids;
 	static const char *sql = "select tableid, array_agg(size order by segid) size from diskquota.table_size group by 1";
-	bool               connected_in_this_function = SPI_connect_if_not_yet();
-	MemoryContext      oldContext                 = MemoryContextSwitchTo(CurTransactionContext);
 
-	initStringInfo(&active_oids);
-	MemoryContextSwitchTo(oldContext);
+	bool connected_in_this_function = SPI_connect_if_not_yet();
+
 	get_typlenbyvalalign(INT8OID, &typlen, &typbyval, &typalign);
 
 	if ((plan = SPI_prepare(sql, 0, NULL)) == NULL)
@@ -953,8 +959,8 @@ load_table_size(void)
 			        DatumGetArrayTypePwrapper(SPI_getbinval_wrapper(val, tupdesc, "size", false, INT8ARRAYOID));
 			Datum *sizes;
 			int    nelems;
-			if (active_oids.len > 0) appendStringInfoString(&active_oids, ",");
-			appendStringInfo(&active_oids, "%d", tableid);
+			if (active_oids->len > 0) appendStringInfoString(active_oids, ",");
+			appendStringInfo(active_oids, "%d", tableid);
 			deconstruct_array(array, ARR_ELEMTYPE(array), typlen, typbyval, typalign, &sizes, NULL, &nelems);
 			Assert(nelems == SEGCOUNT + 1);
 			for (int16 segid = -1; segid < SEGCOUNT; segid++)
@@ -967,8 +973,6 @@ load_table_size(void)
 	SPI_cursor_close(portal);
 	SPI_freeplan(plan);
 	SPI_finish_if(connected_in_this_function);
-
-	return active_oids;
 }
 
 /*
@@ -976,24 +980,19 @@ load_table_size(void)
  * This function is used to prepare the second array parameter
  * of function diskquota_fetch_table_stat.
  */
-static StringInfoData
-convert_map_to_string(HTAB *local_active_table_oid_maps)
+static void
+convert_map_to_string(StringInfoData *active_oids, HTAB *local_active_table_oid_maps)
 {
 	HASH_SEQ_STATUS            iter;
-	StringInfoData             buffer;
 	DiskQuotaActiveTableEntry *entry;
-
-	initStringInfo(&buffer);
 
 	hash_seq_init(&iter, local_active_table_oid_maps);
 
 	while ((entry = (DiskQuotaActiveTableEntry *)hash_seq_search(&iter)) != NULL)
 	{
-		if (buffer.len > 0) appendStringInfoString(&buffer, ",");
-		appendStringInfo(&buffer, "%d", entry->reloid);
+		if (active_oids->len > 0) appendStringInfoString(active_oids, ",");
+		appendStringInfo(active_oids, "%d", entry->reloid);
 	}
-
-	return buffer;
 }
 
 /*
@@ -1002,8 +1001,8 @@ convert_map_to_string(HTAB *local_active_table_oid_maps)
  * Function diskquota_fetch_table_stat is called to calculate
  * the table size on the fly.
  */
-static StringInfoData
-pull_active_list_from_seg(void)
+static void
+pull_active_list_from_seg(StringInfoData *active_oids)
 {
 	CdbPgResults               cdb_pgresults = {NULL, 0};
 	int                        i, j;
@@ -1054,13 +1053,8 @@ pull_active_list_from_seg(void)
 		}
 	}
 	cdbdisp_clearCdbPgResults(&cdb_pgresults);
-
-	MemoryContext  oldContext  = MemoryContextSwitchTo(CurTransactionContext);
-	StringInfoData active_oids = convert_map_to_string(local_active_table_oid_map);
-	MemoryContextSwitchTo(oldContext);
+	convert_map_to_string(active_oids, local_active_table_oid_map);
 	hash_destroy(local_active_table_oid_map);
-
-	return active_oids;
 }
 
 /*
@@ -1072,12 +1066,9 @@ pull_active_list_from_seg(void)
  * memory), so when re-calculate the table size, we need to sum the
  * table size on all of the segments.
  */
-static StringInfoData
-pull_active_table_size_from_seg(HTAB *local_table_stats_map)
+static void
+pull_active_table_size_from_seg(StringInfoData *active_oids, HTAB *local_table_stats_map)
 {
-	/* step 1: fetch active oids from all the segments */
-	StringInfoData active_oids = pull_active_list_from_seg();
-	/* step 2: fetch active table sizes based on active oids */
 	CdbPgResults   cdb_pgresults = {NULL, 0};
 	StringInfoData sql_command;
 	int            i;
@@ -1085,7 +1076,7 @@ pull_active_table_size_from_seg(HTAB *local_table_stats_map)
 
 	initStringInfo(&sql_command);
 	appendStringInfo(&sql_command, "select * from diskquota.diskquota_fetch_table_stat(1, ARRAY[%s]::oid[])",
-	                 active_oids.data);
+	                 active_oids->data);
 	CdbDispatchCommand(sql_command.data, DF_NONE, &cdb_pgresults);
 	pfree(sql_command.data);
 
@@ -1132,5 +1123,4 @@ pull_active_table_size_from_seg(HTAB *local_table_stats_map)
 		}
 	}
 	cdbdisp_clearCdbPgResults(&cdb_pgresults);
-	return active_oids;
 }

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -944,6 +944,7 @@ SPI_getbinval_wrapper(HeapTuple tuple, TupleDesc tupdesc, int fnumber, bool allo
 static void
 load_table_size(StringInfoData *active_oids)
 {
+	TupleDesc  tupdesc;
 	SPIPlanPtr plan;
 	Portal     portal;
 
@@ -963,10 +964,10 @@ load_table_size(StringInfoData *active_oids)
 		ereport(ERROR, (errmsg("[diskquota] load_table_size SPI_cursor_fetch failed")));
 	}
 
-	TupleDesc tupdesc     = SPI_tuptable->tupdesc;
-	int       tableid_num = SPI_fnumber_wrapper(tupdesc, "tableid", OIDOID);
-	int       size_num    = SPI_fnumber_wrapper(tupdesc, "size", INT8OID);
-	int       segid_num   = SPI_fnumber_wrapper(tupdesc, "segid", INT2OID);
+	tupdesc         = SPI_tuptable->tupdesc;
+	int tableid_num = SPI_fnumber_wrapper(tupdesc, "tableid", OIDOID);
+	int size_num    = SPI_fnumber_wrapper(tupdesc, "size", INT8OID);
+	int segid_num   = SPI_fnumber_wrapper(tupdesc, "segid", INT2OID);
 
 	while (SPI_processed > 0)
 	{

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -923,15 +923,10 @@ load_table_size(StringInfoData *active_oids)
 {
 	SPIPlanPtr plan;
 	Portal     portal;
-	int16      typlen;
-	bool       typbyval;
-	char       typalign;
 
-	static const char *sql = "select tableid, array_agg(size order by segid) size from diskquota.table_size group by 1";
+	static const char *sql = "select tableid, size, segid from diskquota.table_size";
 
 	bool connected_in_this_function = SPI_connect_if_not_yet();
-
-	get_typlenbyvalalign(INT8OID, &typlen, &typbyval, &typalign);
 
 	if ((plan = SPI_prepare(sql, 0, NULL)) == NULL)
 		ereport(ERROR, (errmsg("[diskquota] SPI_prepare(\"%s\") failed", sql)));
@@ -943,20 +938,19 @@ load_table_size(StringInfoData *active_oids)
 		SPI_cursor_fetch(portal, true, 10000);
 		for (uint64 row = 0; row < SPI_processed; row++)
 		{
-			HeapTuple  val     = SPI_tuptable->vals[row];
-			TupleDesc  tupdesc = SPI_tuptable->tupdesc;
-			Oid        tableid = DatumGetObjectId(SPI_getbinval_wrapper(val, tupdesc, "tableid", false, OIDOID));
-			ArrayType *array =
-			        DatumGetArrayTypePwrapper(SPI_getbinval_wrapper(val, tupdesc, "size", false, INT8ARRAYOID));
-			Datum *sizes;
-			int    nelems;
-			if (active_oids->len > 0) appendStringInfoString(active_oids, ",");
-			appendStringInfo(active_oids, "%d", tableid);
-			deconstruct_array(array, ARR_ELEMTYPE(array), typlen, typbyval, typalign, &sizes, NULL, &nelems);
-			Assert(nelems == SEGCOUNT + 1);
-			for (int16 segid = -1; segid < SEGCOUNT; segid++)
-				update_active_table_size(tableid, DatumGetInt64(sizes[segid + 1]), segid);
-			pfree(sizes);
+			HeapTuple val     = SPI_tuptable->vals[row];
+			TupleDesc tupdesc = SPI_tuptable->tupdesc;
+			Oid       oid     = DatumGetObjectId(SPI_getbinval_wrapper(val, tupdesc, "tableid", false, OIDOID));
+			int64     size    = DatumGetObjectId(SPI_getbinval_wrapper(val, tupdesc, "size", false, INT8OID));
+			int16     segid   = DatumGetObjectId(SPI_getbinval_wrapper(val, tupdesc, "segid", false, INT2OID));
+
+			update_active_table_size(oid, size, segid);
+
+			if (segid == -1)
+			{
+				if (active_oids->len > 0) appendStringInfoString(active_oids, ",");
+				appendStringInfo(active_oids, "%d", oid);
+			}
 		}
 		SPI_freetuptable(SPI_tuptable);
 	} while (SPI_processed);

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -1018,7 +1018,6 @@ pull_active_list_from_seg(StringInfoData *active_oids)
 
 	/* any errors will be catch in upper level */
 	CdbDispatchCommand(sql, DF_NONE, &cdb_pgresults);
-
 	for (i = 0; i < cdb_pgresults.numResults; i++)
 	{
 		Oid       reloid;

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -952,6 +952,7 @@ load_table_size(StringInfoData *active_oids)
 
 	while (SPI_processed > 0)
 	{
+		/* push the table oid to active_oids and size into table_size_map */
 		for (i = 0; i < SPI_processed; i++)
 		{
 			HeapTuple tup = SPI_tuptable->vals[i];

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -945,6 +945,7 @@ static void
 load_table_size(StringInfoData *active_oids)
 {
 	TupleDesc  tupdesc;
+	int        i;
 	SPIPlanPtr plan;
 	Portal     portal;
 
@@ -971,9 +972,9 @@ load_table_size(StringInfoData *active_oids)
 
 	while (SPI_processed > 0)
 	{
-		for (uint64 row = 0; row < SPI_processed; row++)
+		for (i = 0; i < SPI_processed; i++)
 		{
-			HeapTuple tup   = SPI_tuptable->vals[row];
+			HeapTuple tup   = SPI_tuptable->vals[i];
 			Oid       oid   = DatumGetObjectId(SPI_getbinval_wrapper(tup, tupdesc, tableid_num, false));
 			int64     size  = DatumGetInt64(SPI_getbinval_wrapper(tup, tupdesc, size_num, false));
 			int16     segid = DatumGetInt16(SPI_getbinval_wrapper(tup, tupdesc, segid_num, false));

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -1013,7 +1013,7 @@ pull_active_table_oid_from_seg(StringInfoData *active_oids)
 		/* push the active table oid into oid_map */
 		for (int row = 0; row < PQntuples(pgresult); row++)
 		{
-			Oid oid = atooid(PQgetvalue(pgresult, row, PQfnumber(pgresult, "TABLE_OID")));
+			Oid oid = atooid(PQgetvalue(pgresult, row, PQfnumber(pgresult, "\"TABLE_OID\"")));
 			(void)hash_search(oid_map, &oid, HASH_ENTER, NULL);
 		}
 	}
@@ -1072,8 +1072,8 @@ pull_active_table_size_from_seg(const char *active_oids)
 		for (int row = 0; row < PQntuples(pgresult); row++)
 		{
 			bool  found;
-			Oid   oid  = atooid(PQgetvalue(pgresult, row, PQfnumber(pgresult, "TABLE_OID")));
-			int64 size = atoll(PQgetvalue(pgresult, row, PQfnumber(pgresult, "TABLE_SIZE")));
+			Oid   oid  = atooid(PQgetvalue(pgresult, row, PQfnumber(pgresult, "\"TABLE_OID\"")));
+			int64 size = atoll(PQgetvalue(pgresult, row, PQfnumber(pgresult, "\"TABLE_SIZE\"")));
 
 			update_active_table_size(oid, size, segid);
 			oid_size = hash_search(map, &oid, HASH_ENTER, &found);

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -88,17 +88,15 @@ static void object_access_hook_QuotaStmt(ObjectAccessType access, Oid classId, O
 
 static HTAB *get_active_tables_stats(ArrayType *array);
 static HTAB *get_active_tables_oid(void);
-
-static void pull_active_list_from_seg(StringInfoData *active_oids);
-static void pull_active_table_size_from_seg(StringInfoData *active_oids, HTAB *local_table_stats_map);
-static void convert_map_to_string(StringInfoData *active_oids, HTAB *active_list);
-static void load_table_size(StringInfoData *active_oids);
-
-static void report_active_table_helper(const RelFileNodeBackend *relFileNode);
-static void remove_from_active_table_map(const RelFileNodeBackend *relFileNode);
-static void report_relation_cache_helper(Oid relid);
-static void report_altered_reloid(Oid reloid);
-static Oid  get_dbid(ArrayType *array);
+static HTAB *pull_active_list_from_seg(void);
+static void  pull_active_table_size_from_seg(StringInfoData *active_oids, HTAB *local_table_stats_map);
+static void  convert_map_to_string(StringInfoData *active_oids, HTAB *active_list);
+static void  load_table_size(StringInfoData *active_oids);
+static void  report_active_table_helper(const RelFileNodeBackend *relFileNode);
+static void  remove_from_active_table_map(const RelFileNodeBackend *relFileNode);
+static void  report_relation_cache_helper(Oid relid);
+static void  report_altered_reloid(Oid reloid);
+static Oid   get_dbid(ArrayType *array);
 
 void init_active_table_hook(void);
 void init_shm_worker_active_tables(void);
@@ -368,14 +366,7 @@ remove_from_active_table_map(const RelFileNodeBackend *relFileNode)
 void
 gp_fetch_active_tables(StringInfoData *active_oids, HTAB *local_active_table_stat_map)
 {
-	HASHCTL ctl;
-
 	Assert(Gp_role == GP_ROLE_DISPATCH);
-
-	memset(&ctl, 0, sizeof(ctl));
-	ctl.keysize   = sizeof(Oid);
-	ctl.entrysize = sizeof(ActiveTableEntryCombined) + SEGCOUNT * sizeof(Size);
-	ctl.hcxt      = CurrentMemoryContext;
 
 	if (local_active_table_stat_map == NULL)
 	{
@@ -384,7 +375,10 @@ gp_fetch_active_tables(StringInfoData *active_oids, HTAB *local_active_table_sta
 	else
 	{
 		/* step 1: fetch active oids from all the segments */
-		pull_active_list_from_seg(active_oids);
+		HTAB *local_active_table_oid_maps = pull_active_list_from_seg();
+
+		convert_map_to_string(active_oids, local_active_table_oid_maps);
+		hash_destroy(local_active_table_oid_maps);
 
 		ereport(DEBUG1,
 		        (errcode(ERRCODE_INTERNAL_ERROR), errmsg("[diskquota] active_old_list = %s", active_oids->data)));
@@ -1001,8 +995,8 @@ convert_map_to_string(StringInfoData *active_oids, HTAB *local_active_table_oid_
  * Function diskquota_fetch_table_stat is called to calculate
  * the table size on the fly.
  */
-static void
-pull_active_list_from_seg(StringInfoData *active_oids)
+static HTAB *
+pull_active_list_from_seg(void)
 {
 	CdbPgResults               cdb_pgresults = {NULL, 0};
 	int                        i, j;
@@ -1053,8 +1047,8 @@ pull_active_list_from_seg(StringInfoData *active_oids)
 		}
 	}
 	cdbdisp_clearCdbPgResults(&cdb_pgresults);
-	convert_map_to_string(active_oids, local_active_table_oid_map);
-	hash_destroy(local_active_table_oid_map);
+
+	return local_active_table_oid_map;
 }
 
 /*

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -91,6 +91,7 @@ static HTAB *get_active_tables_oid(void);
 
 static StringInfoData pull_active_list_from_seg(void);
 static StringInfoData pull_active_table_size_from_seg(HTAB *local_table_stats_map);
+static StringInfoData convert_map_to_string(HTAB *active_list);
 static StringInfoData load_table_size(void);
 
 static void report_active_table_helper(const RelFileNodeBackend *relFileNode);

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -89,8 +89,8 @@ static void object_access_hook_QuotaStmt(ObjectAccessType access, Oid classId, O
 static HTAB *get_active_tables_stats(ArrayType *array);
 static HTAB *get_active_tables_oid(void);
 static HTAB *pull_active_list_from_seg(void);
-static void  pull_active_table_size_from_seg(StringInfoData *active_oids, HTAB *local_table_stats_map);
-static void  convert_map_to_string(StringInfoData *active_oids, HTAB *active_list);
+static void  pull_active_table_size_from_seg(HTAB *local_table_stats_map, StringInfoData *active_oids);
+static void  convert_map_to_string(HTAB *local_table_oid_map, StringInfoData *active_oids);
 static void  load_table_size(StringInfoData *active_oids);
 static void  report_active_table_helper(const RelFileNodeBackend *relFileNode);
 static void  remove_from_active_table_map(const RelFileNodeBackend *relFileNode);
@@ -375,16 +375,16 @@ gp_fetch_active_tables(StringInfoData *active_oids, HTAB *local_table_stats_map)
 	else
 	{
 		/* step 1: fetch active oids from all the segments */
-		HTAB *local_active_table_oid_maps = pull_active_list_from_seg();
+		HTAB *local_table_oid_map = pull_active_list_from_seg();
 
-		convert_map_to_string(active_oids, local_active_table_oid_maps);
-		hash_destroy(local_active_table_oid_maps);
+		convert_map_to_string(local_table_oid_map, active_oids);
+		hash_destroy(local_table_oid_map);
 
 		ereport(DEBUG1,
 		        (errcode(ERRCODE_INTERNAL_ERROR), errmsg("[diskquota] active_old_list = %s", active_oids->data)));
 
 		/* step 2: fetch active table sizes based on active oids */
-		pull_active_table_size_from_seg(active_oids, local_table_stats_map);
+		pull_active_table_size_from_seg(local_table_stats_map, active_oids);
 	}
 }
 
@@ -975,12 +975,12 @@ load_table_size(StringInfoData *active_oids)
  * of function diskquota_fetch_table_stat.
  */
 static void
-convert_map_to_string(StringInfoData *active_oids, HTAB *local_active_table_oid_maps)
+convert_map_to_string(HTAB *local_table_oid_map, StringInfoData *active_oids)
 {
 	HASH_SEQ_STATUS            iter;
 	DiskQuotaActiveTableEntry *entry;
 
-	hash_seq_init(&iter, local_active_table_oid_maps);
+	hash_seq_init(&iter, local_table_oid_map);
 
 	while ((entry = (DiskQuotaActiveTableEntry *)hash_seq_search(&iter)) != NULL)
 	{
@@ -1061,7 +1061,7 @@ pull_active_list_from_seg(void)
  * table size on all of the segments.
  */
 static void
-pull_active_table_size_from_seg(StringInfoData *active_oids, HTAB *local_table_stats_map)
+pull_active_table_size_from_seg(HTAB *local_table_stats_map, StringInfoData *active_oids)
 {
 	CdbPgResults   cdb_pgresults = {NULL, 0};
 	StringInfoData sql_command;

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -1000,6 +1000,8 @@ pull_active_table_oid_from_seg(StringInfoData *active_oids)
 
 	/* any errors will be catch in upper level */
 	CdbDispatchCommand(sql, DF_NONE, &cdb_pgresults);
+	Assert(SEGCOUNT == cdb_pgresults.numResults);
+
 	for (int16 segid = 0; segid < cdb_pgresults.numResults; segid++)
 	{
 		PGresult *pgresult = cdb_pgresults.pg_results[segid];
@@ -1036,30 +1038,24 @@ pull_active_table_oid_from_seg(StringInfoData *active_oids)
 static void
 pull_active_table_size_from_seg(const char *active_oids)
 {
-	CdbPgResults   cdb_pgresults = {NULL, 0};
-	StringInfoData sql;
-
-	initStringInfo(&sql);
-	appendStringInfo(&sql, "select * from diskquota.diskquota_fetch_table_stat(1, ARRAY[%s]::oid[])", active_oids);
-	CdbDispatchCommand(sql.data, DF_NONE, &cdb_pgresults);
-	pfree(sql.data);
-
-	SEGCOUNT = cdb_pgresults.numResults;
-	if (SEGCOUNT <= 0)
-	{
-		ereport(ERROR, (errmsg("[diskquota] there is no active segment, SEGCOUNT is %d", SEGCOUNT)));
-	}
-
 	struct
 	{
 		Oid   oid;
 		int64 size;
 	} * oid_size;
-	HASHCTL ctl = {.keysize = sizeof(Oid), .entrysize = sizeof(*oid_size), .hcxt = CurrentMemoryContext};
-	HTAB   *map = diskquota_hash_create("local active table map with size info", 1024, &ctl, HASH_ELEM | HASH_CONTEXT,
-	                                    DISKQUOTA_OID_HASH);
+	CdbPgResults   cdb_pgresults = {NULL, 0};
+	StringInfoData sql;
+	HASHCTL        ctl = {.keysize = sizeof(Oid), .entrysize = sizeof(*oid_size), .hcxt = CurrentMemoryContext};
+	HTAB *map = diskquota_hash_create("local active table map with size info", 1024, &ctl, HASH_ELEM | HASH_CONTEXT,
+	                                  DISKQUOTA_OID_HASH);
 
-	for (int segid = 0; segid < cdb_pgresults.numResults; segid++)
+	initStringInfo(&sql);
+	appendStringInfo(&sql, "select * from diskquota.diskquota_fetch_table_stat(1, ARRAY[%s]::oid[])", active_oids);
+	CdbDispatchCommand(sql.data, DF_NONE, &cdb_pgresults);
+	pfree(sql.data);
+	Assert(SEGCOUNT == cdb_pgresults.numResults);
+
+	for (int16 segid = 0; segid < cdb_pgresults.numResults; segid++)
 	{
 		PGresult *pgresult = cdb_pgresults.pg_results[segid];
 
@@ -1075,6 +1071,7 @@ pull_active_table_size_from_seg(const char *active_oids)
 			bool  found;
 			Oid   oid  = atooid(PQgetvalue(pgresult, row, PQfnumber(pgresult, "\"TABLE_OID\"")));
 			int64 size = atoll(PQgetvalue(pgresult, row, PQfnumber(pgresult, "\"TABLE_SIZE\"")));
+			Assert(segid == atoll(PQgetvalue(pgresult, row, PQfnumber(pgresult, "\"GP_SEGMENT_ID\""))));
 
 			update_active_table_size(oid, size, segid);
 			oid_size = hash_search(map, &oid, HASH_ENTER, &found);

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -1071,7 +1071,7 @@ pull_active_table_size_from_seg(const char *active_oids)
 			bool  found;
 			Oid   oid  = atooid(PQgetvalue(pgresult, row, PQfnumber(pgresult, "\"TABLE_OID\"")));
 			int64 size = atoll(PQgetvalue(pgresult, row, PQfnumber(pgresult, "\"TABLE_SIZE\"")));
-			Assert(segid == atoll(PQgetvalue(pgresult, row, PQfnumber(pgresult, "\"GP_SEGMENT_ID\""))));
+			Assert(segid == atoi(PQgetvalue(pgresult, row, PQfnumber(pgresult, "\"GP_SEGMENT_ID\""))));
 
 			update_active_table_size(oid, size, segid);
 			oid_size = hash_search(map, &oid, HASH_ENTER, &found);

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -89,7 +89,7 @@ static void object_access_hook_QuotaStmt(ObjectAccessType access, Oid classId, O
 static HTAB *get_active_tables_stats(ArrayType *array);
 static HTAB *get_active_tables_oid(void);
 static void  pull_active_table_oid_from_seg(StringInfoData *active_oids);
-static void  pull_active_table_size_from_seg(HTAB *local_table_stats_map, const char *active_oids);
+static void  pull_active_table_size_from_seg(const char *active_oids);
 static void  convert_map_to_string(HTAB *oid_map, StringInfoData *active_oids);
 static void  load_table_size(StringInfoData *active_oids);
 static void  report_active_table_helper(const RelFileNodeBackend *relFileNode);
@@ -364,11 +364,11 @@ remove_from_active_table_map(const RelFileNodeBackend *relFileNode)
  * to get the real table size at cluster level.
  */
 void
-gp_fetch_active_tables(StringInfoData *active_oids, HTAB *local_table_stats_map)
+gp_fetch_active_tables(bool is_init, StringInfoData *active_oids)
 {
 	Assert(Gp_role == GP_ROLE_DISPATCH);
 
-	if (local_table_stats_map == NULL)
+	if (is_init)
 	{
 		load_table_size(active_oids);
 	}
@@ -381,7 +381,7 @@ gp_fetch_active_tables(StringInfoData *active_oids, HTAB *local_table_stats_map)
 		        (errcode(ERRCODE_INTERNAL_ERROR), errmsg("[diskquota] active_old_list = %s", active_oids->data)));
 
 		/* step 2: fetch active table sizes based on active oids */
-		pull_active_table_size_from_seg(local_table_stats_map, active_oids->data);
+		pull_active_table_size_from_seg(active_oids->data);
 	}
 }
 
@@ -1029,6 +1029,12 @@ pull_active_table_oid_from_seg(StringInfoData *active_oids)
 	hash_destroy(oid_map);
 }
 
+typedef struct OidSize
+{
+	Oid   oid;
+	int64 size;
+} OidSize;
+
 /*
  * Get active table list from all the segments.
  * Since when loading data, there is case where only subset for
@@ -1039,18 +1045,15 @@ pull_active_table_oid_from_seg(StringInfoData *active_oids)
  * table size on all of the segments.
  */
 static void
-pull_active_table_size_from_seg(HTAB *local_table_stats_map, const char *active_oids)
+pull_active_table_size_from_seg(const char *active_oids)
 {
 	CdbPgResults   cdb_pgresults = {NULL, 0};
-	StringInfoData sql_command;
-	int            i;
-	int            j;
+	StringInfoData sql;
 
-	initStringInfo(&sql_command);
-	appendStringInfo(&sql_command, "select * from diskquota.diskquota_fetch_table_stat(1, ARRAY[%s]::oid[])",
-	                 active_oids);
-	CdbDispatchCommand(sql_command.data, DF_NONE, &cdb_pgresults);
-	pfree(sql_command.data);
+	initStringInfo(&sql);
+	appendStringInfo(&sql, "select * from diskquota.diskquota_fetch_table_stat(1, ARRAY[%s]::oid[])", active_oids);
+	CdbDispatchCommand(sql.data, DF_NONE, &cdb_pgresults);
+	pfree(sql.data);
 
 	SEGCOUNT = cdb_pgresults.numResults;
 	if (SEGCOUNT <= 0)
@@ -1058,15 +1061,17 @@ pull_active_table_size_from_seg(HTAB *local_table_stats_map, const char *active_
 		ereport(ERROR, (errmsg("[diskquota] there is no active segment, SEGCOUNT is %d", SEGCOUNT)));
 	}
 
-	/* sum table size from each segment into local_table_stats_map */
-	for (i = 0; i < cdb_pgresults.numResults; i++)
-	{
-		Size                      tableSize;
-		bool                      found;
-		Oid                       reloid;
-		int                       segId;
-		ActiveTableEntryCombined *entry;
+	OidSize *entry;
+	HASHCTL  ctl = {
+	         .keysize   = sizeof(Oid),
+	         .entrysize = sizeof(OidSize),
+	         .hcxt      = CurrentMemoryContext,
+    };
+	HTAB *size_map = diskquota_hash_create("local active table map with relfilenode info", 1024, &ctl,
+	                                       HASH_ELEM | HASH_CONTEXT, DISKQUOTA_OID_HASH);
 
+	for (int i = 0; i < cdb_pgresults.numResults; i++)
+	{
 		PGresult *pgresult = cdb_pgresults.pg_results[i];
 
 		if (PQresultStatus(pgresult) != PGRES_TUPLES_OK)
@@ -1076,23 +1081,30 @@ pull_active_table_size_from_seg(HTAB *local_table_stats_map, const char *active_
 			                       PQresultStatus(pgresult))));
 		}
 
-		for (j = 0; j < PQntuples(pgresult); j++)
+		for (int j = 0; j < PQntuples(pgresult); j++)
 		{
-			reloid    = atooid(PQgetvalue(pgresult, j, 0));
-			tableSize = (Size)atoll(PQgetvalue(pgresult, j, 1));
-			entry     = (ActiveTableEntryCombined *)hash_search(local_table_stats_map, &reloid, HASH_ENTER, &found);
+			bool  found;
+			Oid   tableid = atooid(PQgetvalue(pgresult, j, 0));
+			int64 size    = atoll(PQgetvalue(pgresult, j, 1));
+			int16 segid   = atoi(PQgetvalue(pgresult, j, 2));
 
-			/* for diskquota extension version is 1.0, pgresult doesn't contain segid */
-			if (PQnfields(pgresult) == 3)
-			{
-				/* get the segid, tablesize for each table */
-				segId                       = atoi(PQgetvalue(pgresult, j, 2));
-				entry->tablesize[segId + 1] = tableSize;
-			}
-
-			/* tablesize for index 0 is the sum of tablesize of master and all segments */
-			entry->tablesize[0] = (found ? entry->tablesize[0] : 0) + tableSize;
+			update_active_table_size(tableid, size, segid, NULL);
+			entry = hash_search(size_map, &tableid, HASH_ENTER, &found);
+			/* tablesize for master is the sum of tablesize of master and all segments */
+			entry->size = (found ? entry->size : 0) + size;
 		}
+		// update_active_table_size(tableid0, size0, -1, NULL);
 	}
 	cdbdisp_clearCdbPgResults(&cdb_pgresults);
+
+	HASH_SEQ_STATUS iter;
+
+	hash_seq_init(&iter, size_map);
+
+	while ((entry = hash_seq_search(&iter)) != NULL)
+	{
+		update_active_table_size(entry->oid, entry->size, -1, NULL);
+	}
+
+	hash_destroy(size_map);
 }

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -364,11 +364,11 @@ remove_from_active_table_map(const RelFileNodeBackend *relFileNode)
  * to get the real table size at cluster level.
  */
 void
-gp_fetch_active_tables(StringInfoData *active_oids, HTAB *local_active_table_stat_map)
+gp_fetch_active_tables(StringInfoData *active_oids, HTAB *local_table_stats_map)
 {
 	Assert(Gp_role == GP_ROLE_DISPATCH);
 
-	if (local_active_table_stat_map == NULL)
+	if (local_table_stats_map == NULL)
 	{
 		load_table_size(active_oids);
 	}
@@ -384,7 +384,7 @@ gp_fetch_active_tables(StringInfoData *active_oids, HTAB *local_active_table_sta
 		        (errcode(ERRCODE_INTERNAL_ERROR), errmsg("[diskquota] active_old_list = %s", active_oids->data)));
 
 		/* step 2: fetch active table sizes based on active oids */
-		pull_active_table_size_from_seg(active_oids, local_active_table_stat_map);
+		pull_active_table_size_from_seg(active_oids, local_table_stats_map);
 	}
 }
 

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -999,9 +999,9 @@ pull_active_table_oid_from_seg(StringInfoData *active_oids)
 
 	/* any errors will be catch in upper level */
 	CdbDispatchCommand(sql, DF_NONE, &cdb_pgresults);
-	for (int i = 0; i < cdb_pgresults.numResults; i++)
+	for (int16 segid = 0; segid < cdb_pgresults.numResults; segid++)
 	{
-		PGresult *pgresult = cdb_pgresults.pg_results[i];
+		PGresult *pgresult = cdb_pgresults.pg_results[segid];
 
 		if (PQresultStatus(pgresult) != PGRES_TUPLES_OK)
 		{
@@ -1011,9 +1011,9 @@ pull_active_table_oid_from_seg(StringInfoData *active_oids)
 		}
 
 		/* push the active table oid into oid_map */
-		for (int j = 0; j < PQntuples(pgresult); j++)
+		for (int row = 0; row < PQntuples(pgresult); row++)
 		{
-			Oid reloid = atooid(PQgetvalue(pgresult, j, 0));
+			Oid reloid = atooid(PQgetvalue(pgresult, row, 0));
 			(void)hash_search(oid_map, &reloid, HASH_ENTER, NULL);
 		}
 	}

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -955,7 +955,7 @@ load_table_size(StringInfoData *active_oids)
 			deconstruct_array(array, ARR_ELEMTYPE(array), typlen, typbyval, typalign, &sizes, NULL, &nelems);
 			Assert(nelems == SEGCOUNT + 1);
 			for (int16 segid = -1; segid < SEGCOUNT; segid++)
-				update_active_table_size(tableid, DatumGetInt64(sizes[segid + 1]), segid, NULL);
+				update_active_table_size(tableid, DatumGetInt64(sizes[segid + 1]), segid);
 			pfree(sizes);
 		}
 		SPI_freetuptable(SPI_tuptable);
@@ -1086,12 +1086,11 @@ pull_active_table_size_from_seg(const char *active_oids)
 			int64 size  = atoll(PQgetvalue(pgresult, j, 1));
 			int16 segid = atoi(PQgetvalue(pgresult, j, 2));
 
-			update_active_table_size(oid, size, segid, NULL);
+			update_active_table_size(oid, size, segid);
 			oid_size = hash_search(oid_size_map, &oid, HASH_ENTER, &found);
 			/* tablesize for master is the sum of tablesize of master and all segments */
 			oid_size->size = (found ? oid_size->size : 0) + size;
 		}
-		// update_active_table_size(tableid0, size0, -1, NULL);
 	}
 	cdbdisp_clearCdbPgResults(&cdb_pgresults);
 
@@ -1101,7 +1100,7 @@ pull_active_table_size_from_seg(const char *active_oids)
 
 	while ((oid_size = hash_seq_search(&iter)) != NULL)
 	{
-		update_active_table_size(oid_size->oid, oid_size->size, -1, NULL);
+		update_active_table_size(oid_size->oid, oid_size->size, -1);
 	}
 
 	hash_destroy(oid_size_map);

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -1068,6 +1068,12 @@ pull_active_list_from_seg(StringInfoData *active_oids)
 	hash_destroy(local_active_table_oid_map);
 }
 
+typedef struct OidSize
+{
+	Oid  oid;
+	Size size;
+} OidSize;
+
 /*
  * Get active table list from all the segments.
  * Since when loading data, there is case where only subset for
@@ -1080,16 +1086,12 @@ pull_active_list_from_seg(StringInfoData *active_oids)
 static void
 pull_active_table_size_from_seg(const char *active_oids)
 {
-	struct
-	{
-		Oid   oid;
-		int64 size;
-	} * oid_size;
+	OidSize       *oid_size;
 	CdbPgResults   cdb_pgresults = {NULL, 0};
 	StringInfoData sql_command;
 	int            i;
 	int            j;
-	HASHCTL        ctl = {.keysize = sizeof(Oid), .entrysize = sizeof(*oid_size), .hcxt = CurrentMemoryContext};
+	HASHCTL        ctl = {.keysize = sizeof(Oid), .entrysize = sizeof(OidSize), .hcxt = CurrentMemoryContext};
 	HTAB *map = diskquota_hash_create("local active table map with size info", 1024, &ctl, HASH_ELEM | HASH_CONTEXT,
 	                                  DISKQUOTA_OID_HASH);
 

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -1047,6 +1047,11 @@ pull_active_list_from_seg(StringInfoData *active_oids)
 
 	Assert(active_oids->len == 0);
 
+	/*
+	 * Convert a hash map with oids into a string array
+	 * This is used to prepare the second array parameter
+	 * of function diskquota_fetch_table_stat.
+	 */
 	while ((oid = hash_seq_search(&iter)) != NULL)
 	{
 		if (active_oids->len > 0) appendStringInfoString(active_oids, ",");

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -972,7 +972,7 @@ load_table_size(StringInfoData *active_oids)
 			if (isnull) continue;
 			segid = DatumGetInt16(dat);
 
-			update_active_table_size(reloid, size, segid);
+			calculate_active_table_disk_usage(reloid, size, segid);
 
 			if (segid == -1)
 			{
@@ -1117,7 +1117,7 @@ pull_active_table_size_from_seg(const char *active_oids)
 			tableSize = atoll(PQgetvalue(pgresult, j, 1));
 			segId     = atoi(PQgetvalue(pgresult, j, 2));
 
-			update_active_table_size(reloid, tableSize, segId);
+			calculate_active_table_disk_usage(reloid, tableSize, segId);
 			entry = hash_search(local_table_stats_map, &reloid, HASH_ENTER, &found);
 
 			/* tablesize for master is the sum of tablesize of master and all segments */
@@ -1132,7 +1132,7 @@ pull_active_table_size_from_seg(const char *active_oids)
 
 	while ((entry = hash_seq_search(&iter)) != NULL)
 	{
-		update_active_table_size(entry->reloid, entry->tablesize, -1);
+		calculate_active_table_disk_usage(entry->reloid, entry->tablesize, -1);
 	}
 
 	hash_destroy(local_table_stats_map);

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -88,7 +88,7 @@ static void object_access_hook_QuotaStmt(ObjectAccessType access, Oid classId, O
 
 static HTAB *get_active_tables_stats(ArrayType *array);
 static HTAB *get_active_tables_oid(void);
-static void  pull_active_table_oid_from_seg(StringInfoData *active_oids);
+static void  pull_active_list_from_seg(StringInfoData *active_oids);
 static void  pull_active_table_size_from_seg(const char *active_oids);
 static void  convert_map_to_string(HTAB *map, StringInfoData *buf);
 static void  load_table_size(StringInfoData *active_oids);
@@ -375,7 +375,7 @@ gp_fetch_active_tables(bool is_init, StringInfoData *active_oids)
 	else
 	{
 		/* step 1: fetch active oids from all the segments */
-		pull_active_table_oid_from_seg(active_oids);
+		pull_active_list_from_seg(active_oids);
 
 		ereport(DEBUG1,
 		        (errcode(ERRCODE_INTERNAL_ERROR), errmsg("[diskquota] active_old_list = %s", active_oids->data)));
@@ -987,7 +987,7 @@ convert_map_to_string(HTAB *map, StringInfoData *buf)
  * the table size on the fly.
  */
 static void
-pull_active_table_oid_from_seg(StringInfoData *active_oids)
+pull_active_list_from_seg(StringInfoData *active_oids)
 {
 	CdbPgResults cdb_pgresults = {NULL, 0};
 

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -90,7 +90,7 @@ static HTAB *get_active_tables_stats(ArrayType *array);
 static HTAB *get_active_tables_oid(void);
 static HTAB *pull_active_list_from_seg(void);
 static void  pull_active_table_size_from_seg(HTAB *local_table_stats_map, const char *active_oids);
-static void  convert_map_to_string(HTAB *local_table_oid_map, StringInfoData *active_oids);
+static void  convert_map_to_string(HTAB *oid_map, StringInfoData *active_oids);
 static void  load_table_size(StringInfoData *active_oids);
 static void  report_active_table_helper(const RelFileNodeBackend *relFileNode);
 static void  remove_from_active_table_map(const RelFileNodeBackend *relFileNode);
@@ -375,10 +375,10 @@ gp_fetch_active_tables(StringInfoData *active_oids, HTAB *local_table_stats_map)
 	else
 	{
 		/* step 1: fetch active oids from all the segments */
-		HTAB *local_table_oid_map = pull_active_list_from_seg();
+		HTAB *oid_map = pull_active_list_from_seg();
 
-		convert_map_to_string(local_table_oid_map, active_oids);
-		hash_destroy(local_table_oid_map);
+		convert_map_to_string(oid_map, active_oids);
+		hash_destroy(oid_map);
 
 		ereport(DEBUG1,
 		        (errcode(ERRCODE_INTERNAL_ERROR), errmsg("[diskquota] active_old_list = %s", active_oids->data)));
@@ -975,17 +975,17 @@ load_table_size(StringInfoData *active_oids)
  * of function diskquota_fetch_table_stat.
  */
 static void
-convert_map_to_string(HTAB *local_table_oid_map, StringInfoData *active_oids)
+convert_map_to_string(HTAB *oid_map, StringInfoData *active_oids)
 {
-	HASH_SEQ_STATUS            iter;
-	DiskQuotaActiveTableEntry *entry;
+	HASH_SEQ_STATUS iter;
+	Oid            *oid;
 
-	hash_seq_init(&iter, local_table_oid_map);
+	hash_seq_init(&iter, oid_map);
 
-	while ((entry = (DiskQuotaActiveTableEntry *)hash_seq_search(&iter)) != NULL)
+	while ((oid = hash_seq_search(&iter)) != NULL)
 	{
 		if (active_oids->len > 0) appendStringInfoString(active_oids, ",");
-		appendStringInfo(active_oids, "%d", entry->reloid);
+		appendStringInfo(active_oids, "%d", *oid);
 	}
 }
 
@@ -998,30 +998,18 @@ convert_map_to_string(HTAB *local_table_oid_map, StringInfoData *active_oids)
 static HTAB *
 pull_active_list_from_seg(void)
 {
-	CdbPgResults               cdb_pgresults = {NULL, 0};
-	int                        i, j;
-	char                      *sql                        = NULL;
-	HTAB                      *local_active_table_oid_map = NULL;
-	HASHCTL                    ctl;
-	DiskQuotaActiveTableEntry *entry;
-
-	memset(&ctl, 0, sizeof(ctl));
-	ctl.keysize                = sizeof(Oid);
-	ctl.entrysize              = sizeof(DiskQuotaActiveTableEntry);
-	ctl.hcxt                   = CurrentMemoryContext;
-	local_active_table_oid_map = diskquota_hash_create("local active table map with relfilenode info", 1024, &ctl,
+	CdbPgResults cdb_pgresults = {NULL, 0};
+	HASHCTL      ctl           = {.keysize = sizeof(Oid), .entrysize = sizeof(Oid), .hcxt = CurrentMemoryContext};
+	HTAB        *oid_map       = diskquota_hash_create("local active table map with relfilenode info", 1024, &ctl,
 	                                                   HASH_ELEM | HASH_CONTEXT, DISKQUOTA_OID_HASH);
 
 	/* first get all oid of tables which are active table on any segment */
-	sql = "select * from diskquota.diskquota_fetch_table_stat(0, '{}'::oid[])";
+	static const char *sql = "select * from diskquota.diskquota_fetch_table_stat(0, '{}'::oid[])";
 
 	/* any errors will be catch in upper level */
 	CdbDispatchCommand(sql, DF_NONE, &cdb_pgresults);
-	for (i = 0; i < cdb_pgresults.numResults; i++)
+	for (int i = 0; i < cdb_pgresults.numResults; i++)
 	{
-		Oid  reloid;
-		bool found;
-
 		PGresult *pgresult = cdb_pgresults.pg_results[i];
 
 		if (PQresultStatus(pgresult) != PGRES_TUPLES_OK)
@@ -1031,24 +1019,16 @@ pull_active_list_from_seg(void)
 			                       PQresultStatus(pgresult))));
 		}
 
-		/* push the active table oid into local_active_table_oid_map */
-		for (j = 0; j < PQntuples(pgresult); j++)
+		/* push the active table oid into oid_map */
+		for (int j = 0; j < PQntuples(pgresult); j++)
 		{
-			reloid = atooid(PQgetvalue(pgresult, j, 0));
-
-			entry = (DiskQuotaActiveTableEntry *)hash_search(local_active_table_oid_map, &reloid, HASH_ENTER, &found);
-
-			if (!found)
-			{
-				entry->reloid    = reloid;
-				entry->tablesize = 0;
-				entry->segid     = -1;
-			}
+			Oid reloid = atooid(PQgetvalue(pgresult, j, 0));
+			(void)hash_search(oid_map, &reloid, HASH_ENTER, NULL);
 		}
 	}
 	cdbdisp_clearCdbPgResults(&cdb_pgresults);
 
-	return local_active_table_oid_map;
+	return oid_map;
 }
 
 /*

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -35,6 +35,7 @@
 #include "storage/smgr.h"
 #include "utils/faultinjector.h"
 #include "utils/lsyscache.h"
+#include "utils/memutils.h"
 #include "utils/syscache.h"
 #include "utils/inval.h"
 
@@ -85,22 +86,22 @@ static void active_table_hook_smgrtruncate(RelFileNodeBackend rnode);
 static void active_table_hook_smgrunlink(RelFileNodeBackend rnode);
 static void object_access_hook_QuotaStmt(ObjectAccessType access, Oid classId, Oid objectId, int subId, void *arg);
 
-static HTAB          *get_active_tables_stats(ArrayType *array);
-static HTAB          *get_active_tables_oid(void);
-static HTAB          *pull_active_list_from_seg(void);
-static void           pull_active_table_size_from_seg(HTAB *local_table_stats_map, char *active_oid_array);
-static StringInfoData convert_map_to_string(HTAB *active_list);
-static void           load_table_size(HTAB *local_table_stats_map);
-static void           report_active_table_helper(const RelFileNodeBackend *relFileNode);
-static void           remove_from_active_table_map(const RelFileNodeBackend *relFileNode);
-static void           report_relation_cache_helper(Oid relid);
-static void           report_altered_reloid(Oid reloid);
-static Oid            get_dbid(ArrayType *array);
+static HTAB *get_active_tables_stats(ArrayType *array);
+static HTAB *get_active_tables_oid(void);
 
-void  init_active_table_hook(void);
-void  init_shm_worker_active_tables(void);
-void  init_lock_active_tables(void);
-HTAB *gp_fetch_active_tables(bool is_init);
+static StringInfoData pull_active_list_from_seg(void);
+static StringInfoData pull_active_table_size_from_seg(HTAB *local_table_stats_map);
+static StringInfoData load_table_size(void);
+
+static void report_active_table_helper(const RelFileNodeBackend *relFileNode);
+static void remove_from_active_table_map(const RelFileNodeBackend *relFileNode);
+static void report_relation_cache_helper(Oid relid);
+static void report_altered_reloid(Oid reloid);
+static Oid  get_dbid(ArrayType *array);
+
+void init_active_table_hook(void);
+void init_shm_worker_active_tables(void);
+void init_lock_active_tables(void);
 
 /*
  * Init active_tables_map shared memory
@@ -363,13 +364,10 @@ remove_from_active_table_map(const RelFileNodeBackend *relFileNode)
  * And aggregate the table size on each segment
  * to get the real table size at cluster level.
  */
-HTAB *
-gp_fetch_active_tables(bool is_init)
+StringInfoData
+gp_fetch_active_tables(HTAB *local_active_table_stat_map)
 {
-	HTAB          *local_table_stats_map = NULL;
-	HASHCTL        ctl;
-	HTAB          *local_active_table_oid_maps;
-	StringInfoData active_oid_list;
+	HASHCTL ctl;
 
 	Assert(Gp_role == GP_ROLE_DISPATCH);
 
@@ -378,29 +376,12 @@ gp_fetch_active_tables(bool is_init)
 	ctl.entrysize = sizeof(ActiveTableEntryCombined) + SEGCOUNT * sizeof(Size);
 	ctl.hcxt      = CurrentMemoryContext;
 
-	local_table_stats_map = diskquota_hash_create("local active table map with relfilenode info", 1024, &ctl,
-	                                              HASH_ELEM | HASH_CONTEXT, DISKQUOTA_OID_HASH);
-
-	if (is_init)
+	if (local_active_table_stat_map == NULL)
 	{
-		load_table_size(local_table_stats_map);
+		return load_table_size();
 	}
-	else
-	{
-		/* step 1: fetch active oids from all the segments */
-		local_active_table_oid_maps = pull_active_list_from_seg();
-		active_oid_list             = convert_map_to_string(local_active_table_oid_maps);
 
-		ereport(DEBUG1,
-		        (errcode(ERRCODE_INTERNAL_ERROR), errmsg("[diskquota] active_old_list = %s", active_oid_list.data)));
-
-		/* step 2: fetch active table sizes based on active oids */
-		pull_active_table_size_from_seg(local_table_stats_map, active_oid_list.data);
-
-		hash_destroy(local_active_table_oid_maps);
-		pfree(active_oid_list.data);
-	}
-	return local_table_stats_map;
+	return pull_active_table_size_from_seg(local_active_table_stat_map);
 }
 
 /*
@@ -936,93 +917,57 @@ get_active_tables_oid(void)
  * This is called when system startup, disk quota rejectmap
  * and other shared memory will be warmed up by table_size table.
  */
-static void
-load_table_size(HTAB *local_table_stats_map)
+static StringInfoData
+load_table_size(void)
 {
-	TupleDesc                 tupdesc;
-	int                       i;
-	bool                      found;
-	ActiveTableEntryCombined *quota_entry;
-	SPIPlanPtr                plan;
-	Portal                    portal;
-	char                     *sql                        = "select tableid, size, segid from diskquota.table_size";
-	bool                      connected_in_this_function = SPI_connect_if_not_yet();
+	SPIPlanPtr plan;
+	Portal     portal;
+	int16      typlen;
+	bool       typbyval;
+	char       typalign;
+
+	StringInfoData     active_oids;
+	static const char *sql = "select tableid, array_agg(size order by segid) size from diskquota.table_size group by 1";
+	bool               connected_in_this_function = SPI_connect_if_not_yet();
+	MemoryContext      oldContext                 = MemoryContextSwitchTo(CurTransactionContext);
+
+	initStringInfo(&active_oids);
+	MemoryContextSwitchTo(oldContext);
+	get_typlenbyvalalign(INT8OID, &typlen, &typbyval, &typalign);
 
 	if ((plan = SPI_prepare(sql, 0, NULL)) == NULL)
 		ereport(ERROR, (errmsg("[diskquota] SPI_prepare(\"%s\") failed", sql)));
 	if ((portal = SPI_cursor_open(NULL, plan, NULL, NULL, true)) == NULL)
 		ereport(ERROR, (errmsg("[diskquota] SPI_cursor_open(\"%s\") failed", sql)));
 
-	SPI_cursor_fetch(portal, true, 10000);
-
-	if (SPI_tuptable == NULL)
+	do
 	{
-		ereport(ERROR, (errmsg("[diskquota] load_table_size SPI_cursor_fetch failed")));
-	}
-
-	tupdesc = SPI_tuptable->tupdesc;
-#if GP_VERSION_NUM < 70000
-	if (tupdesc->natts != 3 || ((tupdesc)->attrs[0])->atttypid != OIDOID ||
-	    ((tupdesc)->attrs[1])->atttypid != INT8OID || ((tupdesc)->attrs[2])->atttypid != INT2OID)
-#else
-	if (tupdesc->natts != 3 || ((tupdesc)->attrs[0]).atttypid != OIDOID || ((tupdesc)->attrs[1]).atttypid != INT8OID ||
-	    ((tupdesc)->attrs[2]).atttypid != INT2OID)
-#endif /* GP_VERSION_NUM */
-	{
-		if (tupdesc->natts != 3)
+		SPI_cursor_fetch(portal, true, 10000);
+		for (uint64 row = 0; row < SPI_processed; row++)
 		{
-			ereport(WARNING, (errmsg("[diskquota] tupdesc->natts: %d", tupdesc->natts)));
-		}
-		else
-		{
-#if GP_VERSION_NUM < 70000
-			ereport(WARNING, (errmsg("[diskquota] attrs: %d, %d, %d", tupdesc->attrs[0]->atttypid,
-			                         tupdesc->attrs[1]->atttypid, tupdesc->attrs[2]->atttypid)));
-#else
-			ereport(WARNING, (errmsg("[diskquota] attrs: %d, %d, %d", tupdesc->attrs[0].atttypid,
-			                         tupdesc->attrs[1].atttypid, tupdesc->attrs[2].atttypid)));
-#endif /* GP_VERSION_NUM */
-		}
-		ereport(ERROR, (errmsg("[diskquota] table \"table_size\" is corrupted in database \"%s\","
-		                       " please recreate diskquota extension",
-		                       get_database_name(MyDatabaseId))));
-	}
-
-	while (SPI_processed > 0)
-	{
-		/* push the table oid and size into local_table_stats_map */
-		for (i = 0; i < SPI_processed; i++)
-		{
-			HeapTuple tup = SPI_tuptable->vals[i];
-			Datum     dat;
-			Oid       reloid;
-			int64     size;
-			int16     segid;
-			bool      isnull;
-
-			dat = SPI_getbinval(tup, tupdesc, 1, &isnull);
-			if (isnull) continue;
-			reloid = DatumGetObjectId(dat);
-
-			dat = SPI_getbinval(tup, tupdesc, 2, &isnull);
-			if (isnull) continue;
-			size = DatumGetInt64(dat);
-			dat  = SPI_getbinval(tup, tupdesc, 3, &isnull);
-			if (isnull) continue;
-			segid = DatumGetInt16(dat);
-
-			quota_entry = (ActiveTableEntryCombined *)hash_search(local_table_stats_map, &reloid, HASH_ENTER, &found);
-			quota_entry->reloid               = reloid;
-			quota_entry->tablesize[segid + 1] = size;
+			HeapTuple  val     = SPI_tuptable->vals[row];
+			TupleDesc  tupdesc = SPI_tuptable->tupdesc;
+			Oid        tableid = DatumGetObjectId(SPI_getbinval_wrapper(val, tupdesc, "tableid", false, OIDOID));
+			ArrayType *array =
+			        DatumGetArrayTypePwrapper(SPI_getbinval_wrapper(val, tupdesc, "size", false, INT8ARRAYOID));
+			Datum *sizes;
+			int    nelems;
+			if (active_oids.len > 0) appendStringInfoString(&active_oids, ",");
+			appendStringInfo(&active_oids, "%i", tableid);
+			deconstruct_array(array, ARR_ELEMTYPE(array), typlen, typbyval, typalign, &sizes, NULL, &nelems);
+			Assert(nelems == SEGCOUNT + 1);
+			for (int16 segid = -1; segid < SEGCOUNT; segid++)
+				update_active_table_size(tableid, DatumGetInt64(sizes[segid + 1]), segid, NULL);
+			pfree(sizes);
 		}
 		SPI_freetuptable(SPI_tuptable);
-		SPI_cursor_fetch(portal, true, 10000);
-	}
+	} while (SPI_processed);
 
-	SPI_freetuptable(SPI_tuptable);
 	SPI_cursor_close(portal);
 	SPI_freeplan(plan);
 	SPI_finish_if(connected_in_this_function);
+
+	return active_oids;
 }
 
 /*
@@ -1036,27 +981,16 @@ convert_map_to_string(HTAB *local_active_table_oid_maps)
 	HASH_SEQ_STATUS            iter;
 	StringInfoData             buffer;
 	DiskQuotaActiveTableEntry *entry;
-	uint32                     count  = 0;
-	uint32                     nitems = hash_get_num_entries(local_active_table_oid_maps);
 
 	initStringInfo(&buffer);
-	appendStringInfo(&buffer, "{");
 
 	hash_seq_init(&iter, local_active_table_oid_maps);
 
 	while ((entry = (DiskQuotaActiveTableEntry *)hash_seq_search(&iter)) != NULL)
 	{
-		count++;
-		if (count != nitems)
-		{
-			appendStringInfo(&buffer, "%d,", entry->reloid);
-		}
-		else
-		{
-			appendStringInfo(&buffer, "%d", entry->reloid);
-		}
+		if (buffer.len > 0) appendStringInfoString(&buffer, ",");
+		appendStringInfo(&buffer, "%d", entry->reloid);
 	}
-	appendStringInfo(&buffer, "}");
 
 	return buffer;
 }
@@ -1067,7 +1001,7 @@ convert_map_to_string(HTAB *local_active_table_oid_maps)
  * Function diskquota_fetch_table_stat is called to calculate
  * the table size on the fly.
  */
-static HTAB *
+static StringInfoData
 pull_active_list_from_seg(void)
 {
 	CdbPgResults               cdb_pgresults = {NULL, 0};
@@ -1120,7 +1054,10 @@ pull_active_list_from_seg(void)
 	}
 	cdbdisp_clearCdbPgResults(&cdb_pgresults);
 
-	return local_active_table_oid_map;
+	StringInfoData active_oids = convert_map_to_string(local_active_table_oid_map);
+	hash_destroy(local_active_table_oid_map);
+
+	return active_oids;
 }
 
 /*
@@ -1132,17 +1069,20 @@ pull_active_list_from_seg(void)
  * memory), so when re-calculate the table size, we need to sum the
  * table size on all of the segments.
  */
-static void
-pull_active_table_size_from_seg(HTAB *local_table_stats_map, char *active_oid_array)
+static StringInfoData
+pull_active_table_size_from_seg(HTAB *local_table_stats_map)
 {
+	/* step 1: fetch active oids from all the segments */
+	StringInfoData active_oids = pull_active_list_from_seg();
+	/* step 2: fetch active table sizes based on active oids */
 	CdbPgResults   cdb_pgresults = {NULL, 0};
 	StringInfoData sql_command;
 	int            i;
 	int            j;
 
 	initStringInfo(&sql_command);
-	appendStringInfo(&sql_command, "select * from diskquota.diskquota_fetch_table_stat(1, '%s'::oid[])",
-	                 active_oid_array);
+	appendStringInfo(&sql_command, "select * from diskquota.diskquota_fetch_table_stat(1, '{%s}'::oid[])",
+	                 active_oids.data);
 	CdbDispatchCommand(sql_command.data, DF_NONE, &cdb_pgresults);
 	pfree(sql_command.data);
 
@@ -1189,5 +1129,5 @@ pull_active_table_size_from_seg(HTAB *local_table_stats_map, char *active_oid_ar
 		}
 	}
 	cdbdisp_clearCdbPgResults(&cdb_pgresults);
-	return;
+	return active_oids;
 }

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -1069,12 +1069,12 @@ pull_active_table_size_from_seg(const char *active_oids)
 			                       PQresultStatus(pgresult))));
 		}
 
-		for (int j = 0; j < PQntuples(pgresult); j++)
+		for (int row = 0; row < PQntuples(pgresult); row++)
 		{
 			bool  found;
-			Oid   oid   = atooid(PQgetvalue(pgresult, j, 0));
-			int64 size  = atoll(PQgetvalue(pgresult, j, 1));
-			int16 segid = atoi(PQgetvalue(pgresult, j, 2));
+			Oid   oid   = atooid(PQgetvalue(pgresult, row, 0));
+			int64 size  = atoll(PQgetvalue(pgresult, row, 1));
+			int16 segid = atoi(PQgetvalue(pgresult, row, 2));
 
 			update_active_table_size(oid, size, segid);
 			oid_size = hash_search(oid_size_map, &oid, HASH_ENTER, &found);

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -1101,12 +1101,7 @@ pull_active_table_size_from_seg(const char *active_oids)
 
 	for (i = 0; i < cdb_pgresults.numResults; i++)
 	{
-		PGresult *pgresult   = cdb_pgresults.pg_results[i];
-		int       TABLE_OID  = PQfnumber(pgresult, "\"TABLE_OID\"");
-		int       TABLE_SIZE = PQfnumber(pgresult, "\"TABLE_SIZE\"");
-#ifdef USE_ASSERT_CHECKING
-		int GP_SEGMENT_ID = PQfnumber(pgresult, "\"GP_SEGMENT_ID\"");
-#endif
+		PGresult *pgresult = cdb_pgresults.pg_results[i];
 
 		if (PQresultStatus(pgresult) != PGRES_TUPLES_OK)
 		{
@@ -1118,9 +1113,9 @@ pull_active_table_size_from_seg(const char *active_oids)
 		for (j = 0; j < PQntuples(pgresult); j++)
 		{
 			bool  found;
-			Oid   oid  = atooid(PQgetvalue(pgresult, j, TABLE_OID));
-			int64 size = atoll(PQgetvalue(pgresult, j, TABLE_SIZE));
-			Assert(i == atoi(PQgetvalue(pgresult, j, GP_SEGMENT_ID)));
+			Oid   oid  = atooid(PQgetvalue(pgresult, j, 0));
+			int64 size = atoll(PQgetvalue(pgresult, j, 1));
+			Assert(i == atoi(PQgetvalue(pgresult, j, 2)));
 
 			update_active_table_size(oid, size, i);
 			oid_size = hash_search(map, &oid, HASH_ENTER, &found);

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -1062,7 +1062,7 @@ pull_active_list_from_seg(StringInfoData *active_oids)
 			                       PQresultStatus(pgresult))));
 		}
 
-		/* push the active table oid into oid_map */
+		/* push the active table oid into local_active_table_oid_map */
 		for (j = 0; j < PQntuples(pgresult); j++)
 		{
 			reloid = atooid(PQgetvalue(pgresult, j, 0));

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -89,7 +89,6 @@ static HTAB *get_active_tables_stats(ArrayType *array);
 static HTAB *get_active_tables_oid(void);
 static void  pull_active_list_from_seg(StringInfoData *active_oids);
 static void  pull_active_table_size_from_seg(const char *active_oids);
-static void  convert_map_to_string(HTAB *local_active_table_oid_maps, StringInfoData *buf);
 static void  load_table_size(StringInfoData *active_oids);
 static void  report_active_table_helper(const RelFileNodeBackend *relFileNode);
 static void  remove_from_active_table_map(const RelFileNodeBackend *relFileNode);
@@ -992,28 +991,6 @@ load_table_size(StringInfoData *active_oids)
 }
 
 /*
- * Convert a hash map with oids into a string array
- * This function is used to prepare the second array parameter
- * of function diskquota_fetch_table_stat.
- */
-static void
-convert_map_to_string(HTAB *local_active_table_oid_maps, StringInfoData *active_oids)
-{
-	HASH_SEQ_STATUS iter;
-	Oid            *oid;
-
-	hash_seq_init(&iter, local_active_table_oid_maps);
-
-	Assert(active_oids->len == 0);
-
-	while ((oid = hash_seq_search(&iter)) != NULL)
-	{
-		if (active_oids->len > 0) appendStringInfoString(active_oids, ",");
-		appendStringInfo(active_oids, "%d", *oid);
-	}
-}
-
-/*
  * Get active table size from all the segments based on
  * active table oid list.
  * Function diskquota_fetch_table_stat is called to calculate
@@ -1063,7 +1040,19 @@ pull_active_list_from_seg(StringInfoData *active_oids)
 	}
 	cdbdisp_clearCdbPgResults(&cdb_pgresults);
 
-	convert_map_to_string(local_active_table_oid_map, active_oids);
+	HASH_SEQ_STATUS iter;
+	Oid            *oid;
+
+	hash_seq_init(&iter, local_active_table_oid_map);
+
+	Assert(active_oids->len == 0);
+
+	while ((oid = hash_seq_search(&iter)) != NULL)
+	{
+		if (active_oids->len > 0) appendStringInfoString(active_oids, ",");
+		appendStringInfo(active_oids, "%d", *oid);
+	}
+
 	hash_destroy(local_active_table_oid_map);
 }
 

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -926,6 +926,8 @@ load_table_size(StringInfoData *active_oids)
 	char      *sql                        = "select tableid, size, segid from diskquota.table_size";
 	bool       connected_in_this_function = SPI_connect_if_not_yet();
 
+	Assert(active_oids->len == 0);
+
 	if ((plan = SPI_prepare(sql, 0, NULL)) == NULL)
 		ereport(ERROR, (errmsg("[diskquota] SPI_prepare(\"%s\") failed", sql)));
 	if ((portal = SPI_cursor_open(NULL, plan, NULL, NULL, true)) == NULL)
@@ -939,15 +941,32 @@ load_table_size(StringInfoData *active_oids)
 	}
 
 	tupdesc = SPI_tuptable->tupdesc;
-
-	ereportif(SPI_gettypeid(tupdesc, 1) != OIDOID, ERROR,
-	          (errcode(ERRCODE_MOST_SPECIFIC_TYPE_MISMATCH), errmsg("type of column \"tableid\" must be \"OID\"")));
-	ereportif(SPI_gettypeid(tupdesc, 2) != INT8OID, ERROR,
-	          (errcode(ERRCODE_MOST_SPECIFIC_TYPE_MISMATCH), errmsg("type of column \"size\" must be \"INT8\"")));
-	ereportif(SPI_gettypeid(tupdesc, 3) != INT2OID, ERROR,
-	          (errcode(ERRCODE_MOST_SPECIFIC_TYPE_MISMATCH), errmsg("type of column \"segid\" must be \"INT2\"")));
-
-	Assert(active_oids->len == 0);
+#if GP_VERSION_NUM < 70000
+	if (tupdesc->natts != 3 || ((tupdesc)->attrs[0])->atttypid != OIDOID ||
+	    ((tupdesc)->attrs[1])->atttypid != INT8OID || ((tupdesc)->attrs[2])->atttypid != INT2OID)
+#else
+	if (tupdesc->natts != 3 || ((tupdesc)->attrs[0]).atttypid != OIDOID || ((tupdesc)->attrs[1]).atttypid != INT8OID ||
+	    ((tupdesc)->attrs[2]).atttypid != INT2OID)
+#endif /* GP_VERSION_NUM */
+	{
+		if (tupdesc->natts != 3)
+		{
+			ereport(WARNING, (errmsg("[diskquota] tupdesc->natts: %d", tupdesc->natts)));
+		}
+		else
+		{
+#if GP_VERSION_NUM < 70000
+			ereport(WARNING, (errmsg("[diskquota] attrs: %d, %d, %d", tupdesc->attrs[0]->atttypid,
+			                         tupdesc->attrs[1]->atttypid, tupdesc->attrs[2]->atttypid)));
+#else
+			ereport(WARNING, (errmsg("[diskquota] attrs: %d, %d, %d", tupdesc->attrs[0].atttypid,
+			                         tupdesc->attrs[1].atttypid, tupdesc->attrs[2].atttypid)));
+#endif /* GP_VERSION_NUM */
+		}
+		ereport(ERROR, (errmsg("[diskquota] table \"table_size\" is corrupted in database \"%s\","
+		                       " please recreate diskquota extension",
+		                       get_database_name(MyDatabaseId))));
+	}
 
 	while (SPI_processed > 0)
 	{

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -956,11 +956,11 @@ load_table_size(StringInfoData *active_oids)
 	tupdesc = SPI_tuptable->tupdesc;
 
 	ereportif(SPI_gettypeid(tupdesc, 0) != OIDOID, ERROR,
-	          (errcode(ERRCODE_MOST_SPECIFIC_TYPE_MISMATCH), errmsg("type of column \"tableid\" must be \"OIDOID\"")));
+	          (errcode(ERRCODE_MOST_SPECIFIC_TYPE_MISMATCH), errmsg("type of column \"tableid\" must be \"OID\"")));
 	ereportif(SPI_gettypeid(tupdesc, 1) != INT8OID, ERROR,
-	          (errcode(ERRCODE_MOST_SPECIFIC_TYPE_MISMATCH), errmsg("type of column \"size\" must be \"INT8OID\"")));
+	          (errcode(ERRCODE_MOST_SPECIFIC_TYPE_MISMATCH), errmsg("type of column \"size\" must be \"INT8\"")));
 	ereportif(SPI_gettypeid(tupdesc, 2) != INT2OID, ERROR,
-	          (errcode(ERRCODE_MOST_SPECIFIC_TYPE_MISMATCH), errmsg("type of column \"segid\" must be \"INT2OID\"")));
+	          (errcode(ERRCODE_MOST_SPECIFIC_TYPE_MISMATCH), errmsg("type of column \"segid\" must be \"INT2\"")));
 
 	Assert(active_oids->len == 0);
 

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -1086,17 +1086,18 @@ pull_active_table_size_from_seg(const char *active_oids)
 		int64 size;
 	} * oid_size;
 	CdbPgResults   cdb_pgresults = {NULL, 0};
-	StringInfoData sql;
+	StringInfoData sql_command;
 	int            i;
 	int            j;
 	HASHCTL        ctl = {.keysize = sizeof(Oid), .entrysize = sizeof(*oid_size), .hcxt = CurrentMemoryContext};
 	HTAB *map = diskquota_hash_create("local active table map with size info", 1024, &ctl, HASH_ELEM | HASH_CONTEXT,
 	                                  DISKQUOTA_OID_HASH);
 
-	initStringInfo(&sql);
-	appendStringInfo(&sql, "select * from diskquota.diskquota_fetch_table_stat(1, ARRAY[%s]::oid[])", active_oids);
-	CdbDispatchCommand(sql.data, DF_NONE, &cdb_pgresults);
-	pfree(sql.data);
+	initStringInfo(&sql_command);
+	appendStringInfo(&sql_command, "select * from diskquota.diskquota_fetch_table_stat(1, ARRAY[%s]::oid[])",
+	                 active_oids);
+	CdbDispatchCommand(sql_command.data, DF_NONE, &cdb_pgresults);
+	pfree(sql_command.data);
 	Assert(SEGCOUNT == cdb_pgresults.numResults);
 
 	for (i = 0; i < cdb_pgresults.numResults; i++)

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -1100,10 +1100,21 @@ pull_active_table_size_from_seg(const char *active_oids)
 	                 active_oids);
 	CdbDispatchCommand(sql_command.data, DF_NONE, &cdb_pgresults);
 	pfree(sql_command.data);
-	Assert(SEGCOUNT == cdb_pgresults.numResults);
 
+	SEGCOUNT = cdb_pgresults.numResults;
+	if (SEGCOUNT <= 0)
+	{
+		ereport(ERROR, (errmsg("[diskquota] there is no active segment, SEGCOUNT is %d", SEGCOUNT)));
+	}
+
+	/* sum table size from each segment into oid_size map */
 	for (i = 0; i < cdb_pgresults.numResults; i++)
 	{
+		Size tableSize;
+		bool found;
+		Oid  reloid;
+		int  segId;
+
 		PGresult *pgresult = cdb_pgresults.pg_results[i];
 
 		if (PQresultStatus(pgresult) != PGRES_TUPLES_OK)
@@ -1115,15 +1126,15 @@ pull_active_table_size_from_seg(const char *active_oids)
 
 		for (j = 0; j < PQntuples(pgresult); j++)
 		{
-			bool  found;
-			Oid   oid  = atooid(PQgetvalue(pgresult, j, 0));
-			int64 size = atoll(PQgetvalue(pgresult, j, 1));
-			Assert(i == atoi(PQgetvalue(pgresult, j, 2)));
+			reloid    = atooid(PQgetvalue(pgresult, j, 0));
+			tableSize = atoll(PQgetvalue(pgresult, j, 1));
+			segId     = atoi(PQgetvalue(pgresult, j, 2));
 
-			update_active_table_size(oid, size, i);
-			oid_size = hash_search(map, &oid, HASH_ENTER, &found);
+			update_active_table_size(reloid, tableSize, segId);
+			oid_size = hash_search(map, &reloid, HASH_ENTER, &found);
+
 			/* tablesize for master is the sum of tablesize of master and all segments */
-			oid_size->size = (found ? oid_size->size : 0) + size;
+			oid_size->size = (found ? oid_size->size : 0) + tableSize;
 		}
 	}
 	cdbdisp_clearCdbPgResults(&cdb_pgresults);

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -912,18 +912,6 @@ get_active_tables_oid(void)
 	return local_active_table_stats_map;
 }
 
-static int
-SPI_fnumber_wrapper(TupleDesc tupdesc, const char *fname, Oid typeid)
-{
-	int fnumber = SPI_fnumber(tupdesc, fname);
-
-	if (SPI_gettypeid(tupdesc, fnumber) != typeid)
-		ereport(ERROR, (errcode(ERRCODE_MOST_SPECIFIC_TYPE_MISMATCH),
-		                errmsg("type of column \"%s\" must be \"%d\"", fname, typeid)));
-
-	return fnumber;
-}
-
 static Datum
 SPI_getbinval_wrapper(HeapTuple tuple, TupleDesc tupdesc, int fnumber, bool allow_null)
 {
@@ -965,10 +953,14 @@ load_table_size(StringInfoData *active_oids)
 		ereport(ERROR, (errmsg("[diskquota] load_table_size SPI_cursor_fetch failed")));
 	}
 
-	tupdesc         = SPI_tuptable->tupdesc;
-	int tableid_num = SPI_fnumber_wrapper(tupdesc, "tableid", OIDOID);
-	int size_num    = SPI_fnumber_wrapper(tupdesc, "size", INT8OID);
-	int segid_num   = SPI_fnumber_wrapper(tupdesc, "segid", INT2OID);
+	tupdesc = SPI_tuptable->tupdesc;
+
+	ereportif(SPI_gettypeid(tupdesc, 0) != OIDOID, ERROR,
+	          (errcode(ERRCODE_MOST_SPECIFIC_TYPE_MISMATCH), errmsg("type of column \"tableid\" must be \"OIDOID\"")));
+	ereportif(SPI_gettypeid(tupdesc, 1) != INT8OID, ERROR,
+	          (errcode(ERRCODE_MOST_SPECIFIC_TYPE_MISMATCH), errmsg("type of column \"size\" must be \"INT8OID\"")));
+	ereportif(SPI_gettypeid(tupdesc, 2) != INT2OID, ERROR,
+	          (errcode(ERRCODE_MOST_SPECIFIC_TYPE_MISMATCH), errmsg("type of column \"segid\" must be \"INT2OID\"")));
 
 	Assert(active_oids->len == 0);
 
@@ -977,9 +969,9 @@ load_table_size(StringInfoData *active_oids)
 		for (i = 0; i < SPI_processed; i++)
 		{
 			HeapTuple tup   = SPI_tuptable->vals[i];
-			Oid       oid   = DatumGetObjectId(SPI_getbinval_wrapper(tup, tupdesc, tableid_num, false));
-			int64     size  = DatumGetInt64(SPI_getbinval_wrapper(tup, tupdesc, size_num, false));
-			int16     segid = DatumGetInt16(SPI_getbinval_wrapper(tup, tupdesc, segid_num, false));
+			Oid       oid   = DatumGetObjectId(SPI_getbinval_wrapper(tup, tupdesc, 0, false));
+			int64     size  = DatumGetInt64(SPI_getbinval_wrapper(tup, tupdesc, 1, false));
+			int16     segid = DatumGetInt16(SPI_getbinval_wrapper(tup, tupdesc, 2, false));
 
 			update_active_table_size(oid, size, segid);
 

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -1017,7 +1017,6 @@ pull_active_list_from_seg(StringInfoData *active_oids)
 
 	/* any errors will be catch in upper level */
 	CdbDispatchCommand(sql, DF_NONE, &cdb_pgresults);
-	Assert(SEGCOUNT == cdb_pgresults.numResults);
 
 	for (i = 0; i < cdb_pgresults.numResults; i++)
 	{

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -972,6 +972,7 @@ load_table_size(StringInfoData *active_oids)
 			if (isnull) continue;
 			segid = DatumGetInt16(dat);
 
+			/* update sizes for all segments, including master */
 			calculate_active_table_disk_usage(reloid, size, segid);
 
 			if (segid == -1)
@@ -1116,6 +1117,7 @@ pull_active_table_size_from_seg(const char *active_oids)
 			tableSize = atoll(PQgetvalue(pgresult, j, 1));
 			segId     = atoi(PQgetvalue(pgresult, j, 2));
 
+			/* update sizes for all segments, excluding master */
 			calculate_active_table_disk_usage(reloid, tableSize, segId);
 			entry = hash_search(local_table_stats_map, &reloid, HASH_ENTER, &found);
 
@@ -1131,6 +1133,7 @@ pull_active_table_size_from_seg(const char *active_oids)
 
 	while ((entry = hash_seq_search(&iter)) != NULL)
 	{
+		/* update sizes for master only */
 		calculate_active_table_disk_usage(entry->reloid, entry->tablesize, -1);
 	}
 

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -1088,6 +1088,8 @@ pull_active_table_size_from_seg(const char *active_oids)
 	} * oid_size;
 	CdbPgResults   cdb_pgresults = {NULL, 0};
 	StringInfoData sql;
+	int            i;
+	int            j;
 	HASHCTL        ctl = {.keysize = sizeof(Oid), .entrysize = sizeof(*oid_size), .hcxt = CurrentMemoryContext};
 	HTAB *map = diskquota_hash_create("local active table map with size info", 1024, &ctl, HASH_ELEM | HASH_CONTEXT,
 	                                  DISKQUOTA_OID_HASH);
@@ -1098,9 +1100,9 @@ pull_active_table_size_from_seg(const char *active_oids)
 	pfree(sql.data);
 	Assert(SEGCOUNT == cdb_pgresults.numResults);
 
-	for (int16 segid = 0; segid < SEGCOUNT; segid++)
+	for (i = 0; i < cdb_pgresults.numResults; i++)
 	{
-		PGresult *pgresult   = cdb_pgresults.pg_results[segid];
+		PGresult *pgresult   = cdb_pgresults.pg_results[i];
 		int       TABLE_OID  = PQfnumber(pgresult, "\"TABLE_OID\"");
 		int       TABLE_SIZE = PQfnumber(pgresult, "\"TABLE_SIZE\"");
 #ifdef USE_ASSERT_CHECKING
@@ -1114,14 +1116,14 @@ pull_active_table_size_from_seg(const char *active_oids)
 			                       PQresultStatus(pgresult))));
 		}
 
-		for (int row = 0; row < PQntuples(pgresult); row++)
+		for (j = 0; j < PQntuples(pgresult); j++)
 		{
 			bool  found;
-			Oid   oid  = atooid(PQgetvalue(pgresult, row, TABLE_OID));
-			int64 size = atoll(PQgetvalue(pgresult, row, TABLE_SIZE));
-			Assert(segid == atoi(PQgetvalue(pgresult, row, GP_SEGMENT_ID)));
+			Oid   oid  = atooid(PQgetvalue(pgresult, j, TABLE_OID));
+			int64 size = atoll(PQgetvalue(pgresult, j, TABLE_SIZE));
+			Assert(i == atoi(PQgetvalue(pgresult, j, GP_SEGMENT_ID)));
 
-			update_active_table_size(oid, size, segid);
+			update_active_table_size(oid, size, i);
 			oid_size = hash_search(map, &oid, HASH_ENTER, &found);
 			/* tablesize for master is the sum of tablesize of master and all segments */
 			oid_size->size = (found ? oid_size->size : 0) + size;

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -1004,7 +1004,8 @@ pull_active_list_from_seg(StringInfoData *active_oids)
 
 	for (int16 segid = 0; segid < SEGCOUNT; segid++)
 	{
-		PGresult *pgresult = cdb_pgresults.pg_results[segid];
+		PGresult *pgresult  = cdb_pgresults.pg_results[segid];
+		int       TABLE_OID = PQfnumber(pgresult, "\"TABLE_OID\"");
 
 		if (PQresultStatus(pgresult) != PGRES_TUPLES_OK)
 		{
@@ -1016,7 +1017,7 @@ pull_active_list_from_seg(StringInfoData *active_oids)
 		/* push the active table oid into oid_map */
 		for (int row = 0; row < PQntuples(pgresult); row++)
 		{
-			Oid oid = atooid(PQgetvalue(pgresult, row, PQfnumber(pgresult, "\"TABLE_OID\"")));
+			Oid oid = atooid(PQgetvalue(pgresult, row, TABLE_OID));
 			(void)hash_search(map, &oid, HASH_ENTER, NULL);
 		}
 	}
@@ -1057,7 +1058,12 @@ pull_active_table_size_from_seg(const char *active_oids)
 
 	for (int16 segid = 0; segid < SEGCOUNT; segid++)
 	{
-		PGresult *pgresult = cdb_pgresults.pg_results[segid];
+		PGresult *pgresult   = cdb_pgresults.pg_results[segid];
+		int       TABLE_OID  = PQfnumber(pgresult, "\"TABLE_OID\"");
+		int       TABLE_SIZE = PQfnumber(pgresult, "\"TABLE_SIZE\"");
+#ifdef USE_ASSERT_CHECKING
+		int GP_SEGMENT_ID = PQfnumber(pgresult, "\"GP_SEGMENT_ID\"");
+#endif
 
 		if (PQresultStatus(pgresult) != PGRES_TUPLES_OK)
 		{
@@ -1069,9 +1075,9 @@ pull_active_table_size_from_seg(const char *active_oids)
 		for (int row = 0; row < PQntuples(pgresult); row++)
 		{
 			bool  found;
-			Oid   oid  = atooid(PQgetvalue(pgresult, row, PQfnumber(pgresult, "\"TABLE_OID\"")));
-			int64 size = atoll(PQgetvalue(pgresult, row, PQfnumber(pgresult, "\"TABLE_SIZE\"")));
-			Assert(segid == atoi(PQgetvalue(pgresult, row, PQfnumber(pgresult, "\"GP_SEGMENT_ID\""))));
+			Oid   oid  = atooid(PQgetvalue(pgresult, row, TABLE_OID));
+			int64 size = atoll(PQgetvalue(pgresult, row, TABLE_SIZE));
+			Assert(segid == atoi(PQgetvalue(pgresult, row, GP_SEGMENT_ID)));
 
 			update_active_table_size(oid, size, segid);
 			oid_size = hash_search(map, &oid, HASH_ENTER, &found);

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -1061,12 +1061,6 @@ pull_active_list_from_seg(StringInfoData *active_oids)
 	hash_destroy(local_active_table_oid_map);
 }
 
-typedef struct OidSize
-{
-	Oid  reloid;
-	Size tablesize;
-} ActiveTableEntry;
-
 /*
  * Get active table list from all the segments.
  * Since when loading data, there is case where only subset for
@@ -1079,12 +1073,12 @@ typedef struct OidSize
 static void
 pull_active_table_size_from_seg(const char *active_oids)
 {
-	ActiveTableEntry *entry;
-	CdbPgResults      cdb_pgresults = {NULL, 0};
-	StringInfoData    sql_command;
-	int               i;
-	int               j;
-	HASHCTL ctl = {.keysize = sizeof(Oid), .entrysize = sizeof(ActiveTableEntry), .hcxt = CurrentMemoryContext};
+	ActiveTableEntryCombined *entry;
+	CdbPgResults              cdb_pgresults = {NULL, 0};
+	StringInfoData            sql_command;
+	int                       i;
+	int                       j;
+	HASHCTL ctl = {.keysize = sizeof(Oid), .entrysize = sizeof(ActiveTableEntryCombined), .hcxt = CurrentMemoryContext};
 	HTAB   *local_table_stats_map = diskquota_hash_create("local active table map with size info", 1024, &ctl,
 	                                                      HASH_ELEM | HASH_CONTEXT, DISKQUOTA_OID_HASH);
 

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -1031,6 +1031,7 @@ static void
 pull_active_list_from_seg(StringInfoData *active_oids)
 {
 	CdbPgResults cdb_pgresults = {NULL, 0};
+	int          i, j;
 
 	HASHCTL ctl = {.keysize = sizeof(Oid), .entrysize = sizeof(Oid), .hcxt = CurrentMemoryContext};
 	HTAB   *map = diskquota_hash_create("local active table map with relfilenode info", 1024, &ctl,
@@ -1043,10 +1044,10 @@ pull_active_list_from_seg(StringInfoData *active_oids)
 	CdbDispatchCommand(sql, DF_NONE, &cdb_pgresults);
 	Assert(SEGCOUNT == cdb_pgresults.numResults);
 
-	for (int16 segid = 0; segid < SEGCOUNT; segid++)
+	for (i = 0; i < cdb_pgresults.numResults; i++)
 	{
-		PGresult *pgresult  = cdb_pgresults.pg_results[segid];
-		int       TABLE_OID = PQfnumber(pgresult, "\"TABLE_OID\"");
+		Oid       reloid;
+		PGresult *pgresult = cdb_pgresults.pg_results[i];
 
 		if (PQresultStatus(pgresult) != PGRES_TUPLES_OK)
 		{
@@ -1056,10 +1057,10 @@ pull_active_list_from_seg(StringInfoData *active_oids)
 		}
 
 		/* push the active table oid into oid_map */
-		for (int row = 0; row < PQntuples(pgresult); row++)
+		for (j = 0; j < PQntuples(pgresult); j++)
 		{
-			Oid oid = atooid(PQgetvalue(pgresult, row, TABLE_OID));
-			(void)hash_search(map, &oid, HASH_ENTER, NULL);
+			reloid = atooid(PQgetvalue(pgresult, j, 0));
+			(void)hash_search(map, &reloid, HASH_ENTER, NULL);
 		}
 	}
 	cdbdisp_clearCdbPgResults(&cdb_pgresults);

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -954,7 +954,7 @@ load_table_size(void)
 			Datum *sizes;
 			int    nelems;
 			if (active_oids.len > 0) appendStringInfoString(&active_oids, ",");
-			appendStringInfo(&active_oids, "%i", tableid);
+			appendStringInfo(&active_oids, "%d", tableid);
 			deconstruct_array(array, ARR_ELEMTYPE(array), typlen, typbyval, typalign, &sizes, NULL, &nelems);
 			Assert(nelems == SEGCOUNT + 1);
 			for (int16 segid = -1; segid < SEGCOUNT; segid++)

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -912,18 +912,6 @@ get_active_tables_oid(void)
 	return local_active_table_stats_map;
 }
 
-static Datum
-SPI_getbinval_wrapper(HeapTuple tuple, TupleDesc tupdesc, int fnumber, bool allow_null)
-{
-	bool  isnull;
-	Datum datum = SPI_getbinval(tuple, tupdesc, fnumber, &isnull);
-
-	if (isnull && !allow_null)
-		ereport(ERROR, (errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED), errmsg("column %d must not be null", fnumber)));
-
-	return datum;
-}
-
 /*
  * Load table size info from diskquota.table_size table.
  * This is called when system startup, disk quota rejectmap
@@ -955,11 +943,11 @@ load_table_size(StringInfoData *active_oids)
 
 	tupdesc = SPI_tuptable->tupdesc;
 
-	ereportif(SPI_gettypeid(tupdesc, 0) != OIDOID, ERROR,
+	ereportif(SPI_gettypeid(tupdesc, 1) != OIDOID, ERROR,
 	          (errcode(ERRCODE_MOST_SPECIFIC_TYPE_MISMATCH), errmsg("type of column \"tableid\" must be \"OID\"")));
-	ereportif(SPI_gettypeid(tupdesc, 1) != INT8OID, ERROR,
+	ereportif(SPI_gettypeid(tupdesc, 2) != INT8OID, ERROR,
 	          (errcode(ERRCODE_MOST_SPECIFIC_TYPE_MISMATCH), errmsg("type of column \"size\" must be \"INT8\"")));
-	ereportif(SPI_gettypeid(tupdesc, 2) != INT2OID, ERROR,
+	ereportif(SPI_gettypeid(tupdesc, 3) != INT2OID, ERROR,
 	          (errcode(ERRCODE_MOST_SPECIFIC_TYPE_MISMATCH), errmsg("type of column \"segid\" must be \"INT2\"")));
 
 	Assert(active_oids->len == 0);
@@ -968,17 +956,30 @@ load_table_size(StringInfoData *active_oids)
 	{
 		for (i = 0; i < SPI_processed; i++)
 		{
-			HeapTuple tup   = SPI_tuptable->vals[i];
-			Oid       oid   = DatumGetObjectId(SPI_getbinval_wrapper(tup, tupdesc, 0, false));
-			int64     size  = DatumGetInt64(SPI_getbinval_wrapper(tup, tupdesc, 1, false));
-			int16     segid = DatumGetInt16(SPI_getbinval_wrapper(tup, tupdesc, 2, false));
+			HeapTuple tup = SPI_tuptable->vals[i];
+			Datum     dat;
+			Oid       reloid;
+			int64     size;
+			int16     segid;
+			bool      isnull;
 
-			update_active_table_size(oid, size, segid);
+			dat = SPI_getbinval(tup, tupdesc, 1, &isnull);
+			if (isnull) continue;
+			reloid = DatumGetObjectId(dat);
+
+			dat = SPI_getbinval(tup, tupdesc, 2, &isnull);
+			if (isnull) continue;
+			size = DatumGetInt64(dat);
+			dat  = SPI_getbinval(tup, tupdesc, 3, &isnull);
+			if (isnull) continue;
+			segid = DatumGetInt16(dat);
+
+			update_active_table_size(reloid, size, segid);
 
 			if (segid == -1)
 			{
 				if (active_oids->len > 0) appendStringInfoString(active_oids, ",");
-				appendStringInfo(active_oids, "%d", oid);
+				appendStringInfo(active_oids, "%d", reloid);
 			}
 		}
 		SPI_freetuptable(SPI_tuptable);

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -1032,13 +1032,19 @@ pull_active_list_from_seg(StringInfoData *active_oids)
 {
 	CdbPgResults cdb_pgresults = {NULL, 0};
 	int          i, j;
+	char        *sql                        = NULL;
+	HTAB        *local_active_table_oid_map = NULL;
+	HASHCTL      ctl;
 
-	HASHCTL ctl = {.keysize = sizeof(Oid), .entrysize = sizeof(Oid), .hcxt = CurrentMemoryContext};
-	HTAB   *map = diskquota_hash_create("local active table map with relfilenode info", 1024, &ctl,
-	                                    HASH_ELEM | HASH_CONTEXT, DISKQUOTA_OID_HASH);
+	memset(&ctl, 0, sizeof(ctl));
+	ctl.keysize                = sizeof(Oid);
+	ctl.entrysize              = sizeof(Oid);
+	ctl.hcxt                   = CurrentMemoryContext;
+	local_active_table_oid_map = diskquota_hash_create("local active table map with relfilenode info", 1024, &ctl,
+	                                                   HASH_ELEM | HASH_CONTEXT, DISKQUOTA_OID_HASH);
 
 	/* first get all oid of tables which are active table on any segment */
-	static const char *sql = "select * from diskquota.diskquota_fetch_table_stat(0, ARRAY[]::oid[])";
+	sql = "select * from diskquota.diskquota_fetch_table_stat(0, '{}'::oid[])";
 
 	/* any errors will be catch in upper level */
 	CdbDispatchCommand(sql, DF_NONE, &cdb_pgresults);
@@ -1060,13 +1066,13 @@ pull_active_list_from_seg(StringInfoData *active_oids)
 		for (j = 0; j < PQntuples(pgresult); j++)
 		{
 			reloid = atooid(PQgetvalue(pgresult, j, 0));
-			(void)hash_search(map, &reloid, HASH_ENTER, NULL);
+			(void)hash_search(local_active_table_oid_map, &reloid, HASH_ENTER, NULL);
 		}
 	}
 	cdbdisp_clearCdbPgResults(&cdb_pgresults);
 
-	convert_map_to_string(map, active_oids);
-	hash_destroy(map);
+	convert_map_to_string(local_active_table_oid_map, active_oids);
+	hash_destroy(local_active_table_oid_map);
 }
 
 /*

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -1070,9 +1070,9 @@ pull_active_list_from_seg(StringInfoData *active_oids)
 
 typedef struct OidSize
 {
-	Oid  oid;
-	Size size;
-} OidSize;
+	Oid  reloid;
+	Size tablesize;
+} ActiveTableEntry;
 
 /*
  * Get active table list from all the segments.
@@ -1086,14 +1086,14 @@ typedef struct OidSize
 static void
 pull_active_table_size_from_seg(const char *active_oids)
 {
-	OidSize       *oid_size;
-	CdbPgResults   cdb_pgresults = {NULL, 0};
-	StringInfoData sql_command;
-	int            i;
-	int            j;
-	HASHCTL        ctl = {.keysize = sizeof(Oid), .entrysize = sizeof(OidSize), .hcxt = CurrentMemoryContext};
-	HTAB *map = diskquota_hash_create("local active table map with size info", 1024, &ctl, HASH_ELEM | HASH_CONTEXT,
-	                                  DISKQUOTA_OID_HASH);
+	ActiveTableEntry *entry;
+	CdbPgResults      cdb_pgresults = {NULL, 0};
+	StringInfoData    sql_command;
+	int               i;
+	int               j;
+	HASHCTL ctl = {.keysize = sizeof(Oid), .entrysize = sizeof(ActiveTableEntry), .hcxt = CurrentMemoryContext};
+	HTAB   *local_table_stats_map = diskquota_hash_create("local active table map with size info", 1024, &ctl,
+	                                                      HASH_ELEM | HASH_CONTEXT, DISKQUOTA_OID_HASH);
 
 	initStringInfo(&sql_command);
 	appendStringInfo(&sql_command, "select * from diskquota.diskquota_fetch_table_stat(1, ARRAY[%s]::oid[])",
@@ -1107,7 +1107,7 @@ pull_active_table_size_from_seg(const char *active_oids)
 		ereport(ERROR, (errmsg("[diskquota] there is no active segment, SEGCOUNT is %d", SEGCOUNT)));
 	}
 
-	/* sum table size from each segment into oid_size map */
+	/* sum table size from each segment into local_table_stats_map */
 	for (i = 0; i < cdb_pgresults.numResults; i++)
 	{
 		Size tableSize;
@@ -1131,22 +1131,22 @@ pull_active_table_size_from_seg(const char *active_oids)
 			segId     = atoi(PQgetvalue(pgresult, j, 2));
 
 			update_active_table_size(reloid, tableSize, segId);
-			oid_size = hash_search(map, &reloid, HASH_ENTER, &found);
+			entry = hash_search(local_table_stats_map, &reloid, HASH_ENTER, &found);
 
 			/* tablesize for master is the sum of tablesize of master and all segments */
-			oid_size->size = (found ? oid_size->size : 0) + tableSize;
+			entry->tablesize = (found ? entry->tablesize : 0) + tableSize;
 		}
 	}
 	cdbdisp_clearCdbPgResults(&cdb_pgresults);
 
 	HASH_SEQ_STATUS iter;
 
-	hash_seq_init(&iter, map);
+	hash_seq_init(&iter, local_table_stats_map);
 
-	while ((oid_size = hash_seq_search(&iter)) != NULL)
+	while ((entry = hash_seq_search(&iter)) != NULL)
 	{
-		update_active_table_size(oid_size->oid, oid_size->size, -1);
+		update_active_table_size(entry->reloid, entry->tablesize, -1);
 	}
 
-	hash_destroy(map);
+	hash_destroy(local_table_stats_map);
 }

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -88,7 +88,7 @@ static void object_access_hook_QuotaStmt(ObjectAccessType access, Oid classId, O
 
 static HTAB *get_active_tables_stats(ArrayType *array);
 static HTAB *get_active_tables_oid(void);
-static HTAB *pull_active_list_from_seg(void);
+static void  pull_active_list_from_seg(StringInfoData *active_oids);
 static void  pull_active_table_size_from_seg(HTAB *local_table_stats_map, const char *active_oids);
 static void  convert_map_to_string(HTAB *oid_map, StringInfoData *active_oids);
 static void  load_table_size(StringInfoData *active_oids);
@@ -375,10 +375,7 @@ gp_fetch_active_tables(StringInfoData *active_oids, HTAB *local_table_stats_map)
 	else
 	{
 		/* step 1: fetch active oids from all the segments */
-		HTAB *oid_map = pull_active_list_from_seg();
-
-		convert_map_to_string(oid_map, active_oids);
-		hash_destroy(oid_map);
+		pull_active_list_from_seg(active_oids);
 
 		ereport(DEBUG1,
 		        (errcode(ERRCODE_INTERNAL_ERROR), errmsg("[diskquota] active_old_list = %s", active_oids->data)));
@@ -995,8 +992,8 @@ convert_map_to_string(HTAB *oid_map, StringInfoData *active_oids)
  * Function diskquota_fetch_table_stat is called to calculate
  * the table size on the fly.
  */
-static HTAB *
-pull_active_list_from_seg(void)
+static void
+pull_active_list_from_seg(StringInfoData *active_oids)
 {
 	CdbPgResults cdb_pgresults = {NULL, 0};
 	HASHCTL      ctl           = {.keysize = sizeof(Oid), .entrysize = sizeof(Oid), .hcxt = CurrentMemoryContext};
@@ -1028,7 +1025,8 @@ pull_active_list_from_seg(void)
 	}
 	cdbdisp_clearCdbPgResults(&cdb_pgresults);
 
-	return oid_map;
+	convert_map_to_string(oid_map, active_oids);
+	hash_destroy(oid_map);
 }
 
 /*

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -89,7 +89,7 @@ static void object_access_hook_QuotaStmt(ObjectAccessType access, Oid classId, O
 static HTAB *get_active_tables_stats(ArrayType *array);
 static HTAB *get_active_tables_oid(void);
 static HTAB *pull_active_list_from_seg(void);
-static void  pull_active_table_size_from_seg(HTAB *local_table_stats_map, StringInfoData *active_oids);
+static void  pull_active_table_size_from_seg(HTAB *local_table_stats_map, const char *active_oids);
 static void  convert_map_to_string(HTAB *local_table_oid_map, StringInfoData *active_oids);
 static void  load_table_size(StringInfoData *active_oids);
 static void  report_active_table_helper(const RelFileNodeBackend *relFileNode);
@@ -384,7 +384,7 @@ gp_fetch_active_tables(StringInfoData *active_oids, HTAB *local_table_stats_map)
 		        (errcode(ERRCODE_INTERNAL_ERROR), errmsg("[diskquota] active_old_list = %s", active_oids->data)));
 
 		/* step 2: fetch active table sizes based on active oids */
-		pull_active_table_size_from_seg(local_table_stats_map, active_oids);
+		pull_active_table_size_from_seg(local_table_stats_map, active_oids->data);
 	}
 }
 
@@ -1061,7 +1061,7 @@ pull_active_list_from_seg(void)
  * table size on all of the segments.
  */
 static void
-pull_active_table_size_from_seg(HTAB *local_table_stats_map, StringInfoData *active_oids)
+pull_active_table_size_from_seg(HTAB *local_table_stats_map, const char *active_oids)
 {
 	CdbPgResults   cdb_pgresults = {NULL, 0};
 	StringInfoData sql_command;
@@ -1070,7 +1070,7 @@ pull_active_table_size_from_seg(HTAB *local_table_stats_map, StringInfoData *act
 
 	initStringInfo(&sql_command);
 	appendStringInfo(&sql_command, "select * from diskquota.diskquota_fetch_table_stat(1, ARRAY[%s]::oid[])",
-	                 active_oids->data);
+	                 active_oids);
 	CdbDispatchCommand(sql_command.data, DF_NONE, &cdb_pgresults);
 	pfree(sql_command.data);
 

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -995,7 +995,7 @@ pull_active_table_oid_from_seg(StringInfoData *active_oids)
 	                                                   HASH_ELEM | HASH_CONTEXT, DISKQUOTA_OID_HASH);
 
 	/* first get all oid of tables which are active table on any segment */
-	static const char *sql = "select * from diskquota.diskquota_fetch_table_stat(0, '{}'::oid[])";
+	static const char *sql = "select * from diskquota.diskquota_fetch_table_stat(0, ARRAY[]::oid[])";
 
 	/* any errors will be catch in upper level */
 	CdbDispatchCommand(sql, DF_NONE, &cdb_pgresults);
@@ -1013,8 +1013,8 @@ pull_active_table_oid_from_seg(StringInfoData *active_oids)
 		/* push the active table oid into oid_map */
 		for (int row = 0; row < PQntuples(pgresult); row++)
 		{
-			Oid reloid = atooid(PQgetvalue(pgresult, row, 0));
-			(void)hash_search(oid_map, &reloid, HASH_ENTER, NULL);
+			Oid oid = atooid(PQgetvalue(pgresult, row, PQfnumber(pgresult, "TABLE_OID")));
+			(void)hash_search(oid_map, &oid, HASH_ENTER, NULL);
 		}
 	}
 	cdbdisp_clearCdbPgResults(&cdb_pgresults);
@@ -1072,8 +1072,8 @@ pull_active_table_size_from_seg(const char *active_oids)
 		for (int row = 0; row < PQntuples(pgresult); row++)
 		{
 			bool  found;
-			Oid   oid  = atooid(PQgetvalue(pgresult, row, 0));
-			int64 size = atoll(PQgetvalue(pgresult, row, 1));
+			Oid   oid  = atooid(PQgetvalue(pgresult, row, PQfnumber(pgresult, "TABLE_OID")));
+			int64 size = atoll(PQgetvalue(pgresult, row, PQfnumber(pgresult, "TABLE_SIZE")));
 
 			update_active_table_size(oid, size, segid);
 			oid_size = hash_search(map, &oid, HASH_ENTER, &found);

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -1002,7 +1002,7 @@ pull_active_list_from_seg(StringInfoData *active_oids)
 	CdbDispatchCommand(sql, DF_NONE, &cdb_pgresults);
 	Assert(SEGCOUNT == cdb_pgresults.numResults);
 
-	for (int16 segid = 0; segid < cdb_pgresults.numResults; segid++)
+	for (int16 segid = 0; segid < SEGCOUNT; segid++)
 	{
 		PGresult *pgresult = cdb_pgresults.pg_results[segid];
 
@@ -1055,7 +1055,7 @@ pull_active_table_size_from_seg(const char *active_oids)
 	pfree(sql.data);
 	Assert(SEGCOUNT == cdb_pgresults.numResults);
 
-	for (int16 segid = 0; segid < cdb_pgresults.numResults; segid++)
+	for (int16 segid = 0; segid < SEGCOUNT; segid++)
 	{
 		PGresult *pgresult = cdb_pgresults.pg_results[segid];
 

--- a/src/gp_activetable.h
+++ b/src/gp_activetable.h
@@ -47,7 +47,7 @@ typedef struct ActiveTableEntryCombined
 	Size tablesize[1];
 } ActiveTableEntryCombined;
 
-extern StringInfoData gp_fetch_active_tables(HTAB *local_active_table_stat_map);
+extern void gp_fetch_active_tables(StringInfoData *active_oids, HTAB *local_active_table_stat_map);
 
 extern void init_active_table_hook(void);
 extern void init_shm_worker_active_tables(void);

--- a/src/gp_activetable.h
+++ b/src/gp_activetable.h
@@ -37,17 +37,7 @@ typedef struct DiskQuotaActiveTableEntry
 	Size tablesize;
 } DiskQuotaActiveTableEntry;
 
-typedef struct ActiveTableEntryCombined
-{
-	Oid reloid;
-	/*
-	 Variable length array: index 0 is used for the coordinator,
-	 the remaining SEGCOUNT indexes are for segments.
-	 */
-	Size tablesize[1];
-} ActiveTableEntryCombined;
-
-extern void gp_fetch_active_tables(StringInfoData *active_oids, HTAB *local_table_stats_map);
+extern void gp_fetch_active_tables(bool is_init, StringInfoData *active_oids);
 extern void init_active_table_hook(void);
 extern void init_shm_worker_active_tables(void);
 extern void init_lock_active_tables(void);

--- a/src/gp_activetable.h
+++ b/src/gp_activetable.h
@@ -37,6 +37,12 @@ typedef struct DiskQuotaActiveTableEntry
 	Size tablesize;
 } DiskQuotaActiveTableEntry;
 
+typedef struct ActiveTableEntryCombined
+{
+	Oid  reloid;
+	Size tablesize;
+} ActiveTableEntryCombined;
+
 extern void gp_fetch_active_tables(bool is_init, StringInfoData *active_oids);
 extern void init_active_table_hook(void);
 extern void init_shm_worker_active_tables(void);

--- a/src/gp_activetable.h
+++ b/src/gp_activetable.h
@@ -41,7 +41,7 @@ extern void gp_fetch_active_tables(bool is_init, StringInfoData *active_oids);
 extern void init_active_table_hook(void);
 extern void init_shm_worker_active_tables(void);
 extern void init_lock_active_tables(void);
-extern void update_active_table_size(Oid tableid, int64 size, int16 segid);
+extern void update_active_table_size(Oid oid, int64 size, int16 segid);
 
 extern HTAB *monitored_dbid_cache;
 

--- a/src/gp_activetable.h
+++ b/src/gp_activetable.h
@@ -47,7 +47,7 @@ extern void gp_fetch_active_tables(bool is_init, StringInfoData *active_oids);
 extern void init_active_table_hook(void);
 extern void init_shm_worker_active_tables(void);
 extern void init_lock_active_tables(void);
-extern void update_active_table_size(Oid oid, int64 size, int16 segid);
+extern void calculate_active_table_disk_usage(Oid oid, int64 size, int16 segid);
 
 extern HTAB *monitored_dbid_cache;
 

--- a/src/gp_activetable.h
+++ b/src/gp_activetable.h
@@ -47,7 +47,7 @@ typedef struct ActiveTableEntryCombined
 	Size tablesize[1];
 } ActiveTableEntryCombined;
 
-extern void gp_fetch_active_tables(StringInfoData *active_oids, HTAB *local_active_table_stat_map);
+extern void gp_fetch_active_tables(StringInfoData *active_oids, HTAB *local_table_stats_map);
 
 extern void init_active_table_hook(void);
 extern void init_shm_worker_active_tables(void);

--- a/src/gp_activetable.h
+++ b/src/gp_activetable.h
@@ -47,10 +47,12 @@ typedef struct ActiveTableEntryCombined
 	Size tablesize[1];
 } ActiveTableEntryCombined;
 
-extern HTAB *gp_fetch_active_tables(bool force);
-extern void  init_active_table_hook(void);
-extern void  init_shm_worker_active_tables(void);
-extern void  init_lock_active_tables(void);
+extern StringInfoData gp_fetch_active_tables(HTAB *local_active_table_stat_map);
+
+extern void init_active_table_hook(void);
+extern void init_shm_worker_active_tables(void);
+extern void init_lock_active_tables(void);
+extern void update_active_table_size(Oid tableid, int64 size, int16 segid, void *arg);
 
 extern HTAB *monitored_dbid_cache;
 

--- a/src/gp_activetable.h
+++ b/src/gp_activetable.h
@@ -48,7 +48,6 @@ typedef struct ActiveTableEntryCombined
 } ActiveTableEntryCombined;
 
 extern void gp_fetch_active_tables(StringInfoData *active_oids, HTAB *local_table_stats_map);
-
 extern void init_active_table_hook(void);
 extern void init_shm_worker_active_tables(void);
 extern void init_lock_active_tables(void);

--- a/src/gp_activetable.h
+++ b/src/gp_activetable.h
@@ -41,7 +41,7 @@ extern void gp_fetch_active_tables(bool is_init, StringInfoData *active_oids);
 extern void init_active_table_hook(void);
 extern void init_shm_worker_active_tables(void);
 extern void init_lock_active_tables(void);
-extern void update_active_table_size(Oid tableid, int64 size, int16 segid, void *arg);
+extern void update_active_table_size(Oid tableid, int64 size, int16 segid);
 
 extern HTAB *monitored_dbid_cache;
 

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -919,9 +919,6 @@ get_table_size_map_entry(Oid oid, int16 segid)
 		for (int j = seg_st; j < seg_ed; j++) TableSizeEntrySetFlushFlag(tsentry, j);
 	}
 
-	/* mark tsentry is_exist */
-	if (tsentry) set_table_size_entry_flag(tsentry, TABLE_EXIST);
-
 	return tsentry;
 }
 
@@ -1075,6 +1072,9 @@ calculate_table_disk_usage(bool is_init)
 				   anymore. */
 				break;
 			}
+
+			/* mark tsentry is_exist */
+			if (tsentry) set_table_size_entry_flag(tsentry, TABLE_EXIST);
 
 			/* table size info doesn't need to flush at init quota model stage */
 			if (is_init)

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -898,18 +898,15 @@ merge_uncommitted_table_to_oidlist(List *oidlist)
 }
 
 static TableSizeEntry *
-get_tsentry(Oid tableid, int16 segid)
+get_tsentry(Oid oid, int16 segid)
 {
-	bool              table_size_map_found;
-	TableSizeEntryKey key = {
-	        .reloid = tableid,
-	        .id     = TableSizeEntryId(segid),
-	};
-	HASHACTION      action  = check_hash_fullness(table_size_map, MAX_NUM_TABLE_SIZE_ENTRIES, table_size_map_warning,
-	                                              table_size_map_last_overflow_report);
-	TableSizeEntry *tsentry = hash_search(table_size_map, &key, action, &table_size_map_found);
+	bool              found;
+	TableSizeEntryKey key     = {.reloid = oid, .id = TableSizeEntryId(segid)};
+	HASHACTION        action  = check_hash_fullness(table_size_map, MAX_NUM_TABLE_SIZE_ENTRIES, table_size_map_warning,
+	                                                table_size_map_last_overflow_report);
+	TableSizeEntry   *tsentry = hash_search(table_size_map, &key, action, &found);
 
-	if (!table_size_map_found && tsentry != NULL)
+	if (!found && tsentry != NULL)
 	{
 		memset(tsentry->totalsize, 0, sizeof(tsentry->totalsize));
 		tsentry->owneroid      = InvalidOid;

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -898,7 +898,7 @@ merge_uncommitted_table_to_oidlist(List *oidlist)
 }
 
 static TableSizeEntry *
-get_tsentry(Oid oid, int16 segid)
+get_table_size_map_entry(Oid oid, int16 segid)
 {
 	bool              found;
 	TableSizeEntryKey key     = {.reloid = oid, .id = TableSizeEntryId(segid)};
@@ -928,7 +928,7 @@ get_tsentry(Oid oid, int16 segid)
 void
 update_active_table_size(Oid oid, int64 size, int16 segid)
 {
-	TableSizeEntry *tsentry = get_tsentry(oid, segid);
+	TableSizeEntry *tsentry = get_table_size_map_entry(oid, segid);
 
 	if (tsentry == NULL)
 	{
@@ -1066,7 +1066,7 @@ calculate_table_disk_usage(bool is_init)
 		 */
 		for (int cur_segid = -1; cur_segid < SEGCOUNT; cur_segid++)
 		{
-			tsentry = get_tsentry(relOid, cur_segid);
+			tsentry = get_table_size_map_entry(relOid, cur_segid);
 
 			if (tsentry == NULL)
 			{

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -933,7 +933,7 @@ update_active_table_size(Oid oid, int64 size, int16 segid)
 	if (tsentry == NULL)
 	{
 		/* Too many tables have been added to the table_size_map, to avoid diskquota using
-		   too much share memory, just quit the loop. The diskquota won't work correctly
+		   too much share memory, just return. The diskquota won't work correctly
 		   anymore. */
 		return;
 	}

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -825,8 +825,12 @@ refresh_disk_quota_usage(bool is_init)
 		/*
 		 * initialization stage all the tables are active. later loop, only the
 		 * tables whose disk size changed will be treated as active
+		 *
+		 * active_oids only contains the active tables which belong
+		 * to the current database.
 		 */
 		gp_fetch_active_tables(is_init, &active_oids);
+		bool hasActiveTable = (active_oids.len > 0);
 		/* TODO: if we can skip the following steps when there is no active table */
 		/* recalculate the disk usage of table, schema and role */
 		calculate_table_disk_usage(is_init);
@@ -842,7 +846,7 @@ refresh_disk_quota_usage(bool is_init)
 		 * Otherwise, only when the rejectmap is changed or the active_table_list is
 		 * not empty the rejectmap should be dispatched to segments.
 		 */
-		if (is_init || (diskquota_hardlimit && (reject_map_changed || active_oids.len > 0)))
+		if (is_init || (diskquota_hardlimit && (reject_map_changed || hasActiveTable)))
 			dispatch_rejectmap(active_oids.data);
 	}
 	PG_CATCH();

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -926,9 +926,9 @@ get_tsentry(Oid oid, int16 segid)
 }
 
 void
-update_active_table_size(Oid tableid, int64 size, int16 segid)
+update_active_table_size(Oid oid, int64 size, int16 segid)
 {
-	TableSizeEntry *tsentry = get_tsentry(tableid, segid);
+	TableSizeEntry *tsentry = get_tsentry(oid, segid);
 
 	if (tsentry == NULL)
 	{
@@ -944,7 +944,7 @@ update_active_table_size(Oid tableid, int64 size, int16 segid)
 		Gp_role = GP_ROLE_UTILITY;
 
 		/* when segid is -1, the size is the sum of size of master and all segments */
-		size += calculate_table_size(tableid);
+		size += calculate_table_size(oid);
 
 		Gp_role = GP_ROLE_DISPATCH;
 	}

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -951,11 +951,9 @@ update_active_table_size(Oid tableid, int64 size, int16 segid, void *arg)
 
 	if (tsentry == NULL)
 	{
-		/*
-		 * Too many tables have been added to the table_size_map, to avoid diskquota using
-		 * too much share memory, just return the function. The diskquota won't work correctly
-		 * anymore.
-		 */
+		/* Too many tables have been added to the table_size_map, to avoid diskquota using
+		   too much share memory, just quit the loop. The diskquota won't work correctly
+		   anymore. */
 		return;
 	}
 
@@ -1091,11 +1089,9 @@ calculate_table_disk_usage(HTAB *local_table_stats_map)
 
 			if (tsentry == NULL)
 			{
-				/*
-				 * Too many tables have been added to the table_size_map, to avoid diskquota using
-				 * too much share memory, just quit the loop. The diskquota won't work correctly
-				 * anymore.
-				 */
+				/* Too many tables have been added to the table_size_map, to avoid diskquota using
+				   too much share memory, just quit the loop. The diskquota won't work correctly
+				   anymore. */
 				break;
 			}
 

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -220,7 +220,7 @@ static void transfer_table_for_quota(int64 totalsize, QuotaType type, Oid *old_k
 
 /* functions to refresh disk quota model*/
 static void refresh_disk_quota_usage(bool is_init);
-static void calculate_table_disk_usage(HTAB *local_active_table_stat_map);
+static void calculate_table_disk_usage(HTAB *local_table_stats_map);
 static void flush_to_table_size(void);
 static bool flush_local_reject_map(void);
 static void dispatch_rejectmap(StringInfoData *active_oids);
@@ -809,9 +809,9 @@ refresh_disk_quota_model(bool is_init)
 static void
 refresh_disk_quota_usage(bool is_init)
 {
-	volatile bool pushed_active_snap           = false;
-	volatile bool ret                          = true;
-	HTAB *volatile local_active_table_stat_map = NULL;
+	volatile bool pushed_active_snap     = false;
+	volatile bool ret                    = true;
+	HTAB *volatile local_table_stats_map = NULL;
 	StringInfoData active_oids;
 
 	StartTransactionCommand();
@@ -830,7 +830,7 @@ refresh_disk_quota_usage(bool is_init)
 		 * initialization stage all the tables are active. later loop, only the
 		 * tables whose disk size changed will be treated as active
 		 *
-		 * local_active_table_stat_map only contains the active tables which belong
+		 * local_table_stats_map only contains the active tables which belong
 		 * to the current database.
 		 */
 		if (!is_init)
@@ -840,13 +840,13 @@ refresh_disk_quota_usage(bool is_init)
 			        .entrysize = sizeof(ActiveTableEntryCombined) + SEGCOUNT * sizeof(Size),
 			        .hcxt      = CurrentMemoryContext,
 			};
-			local_active_table_stat_map = diskquota_hash_create("local active table map with relfilenode info", 1024,
-			                                                    &ctl, HASH_ELEM | HASH_CONTEXT, DISKQUOTA_OID_HASH);
+			local_table_stats_map = diskquota_hash_create("local active table map with relfilenode info", 1024, &ctl,
+			                                              HASH_ELEM | HASH_CONTEXT, DISKQUOTA_OID_HASH);
 		}
-		gp_fetch_active_tables(&active_oids, local_active_table_stat_map);
+		gp_fetch_active_tables(&active_oids, local_table_stats_map);
 		/* TODO: if we can skip the following steps when there is no active table */
 		/* recalculate the disk usage of table, schema and role */
-		calculate_table_disk_usage(local_active_table_stat_map);
+		calculate_table_disk_usage(local_table_stats_map);
 		/* refresh quota_info_map */
 		refresh_quota_info_map();
 		/* flush local table_size_map to user table table_size */
@@ -874,7 +874,7 @@ refresh_disk_quota_usage(bool is_init)
 	}
 	PG_END_TRY();
 	if (active_oids.data) pfree(active_oids.data);
-	if (local_active_table_stat_map) hash_destroy(local_active_table_stat_map);
+	if (local_table_stats_map) hash_destroy(local_table_stats_map);
 	if (pushed_active_snap) PopActiveSnapshot();
 	if (ret)
 		CommitTransactionCommand();
@@ -998,7 +998,7 @@ update_active_table_size(Oid tableid, int64 size, int16 segid, void *arg)
  */
 
 static void
-calculate_table_disk_usage(HTAB *local_active_table_stat_map)
+calculate_table_disk_usage(HTAB *local_table_stats_map)
 {
 	TableSizeEntry *tsentry = NULL;
 	Oid             relOid;
@@ -1022,7 +1022,7 @@ calculate_table_disk_usage(HTAB *local_active_table_stat_map)
 	 * calculate the file size for active table and update namespace_size_map
 	 * and role_size_map
 	 */
-	oidlist = get_rel_oid_list(local_active_table_stat_map == NULL);
+	oidlist = get_rel_oid_list(local_table_stats_map == NULL);
 
 	oidlist = merge_uncommitted_table_to_oidlist(oidlist);
 
@@ -1057,7 +1057,7 @@ calculate_table_disk_usage(HTAB *local_active_table_stat_map)
 				elog(WARNING, "cache lookup failed for relation %u", relOid);
 				LWLockRelease(diskquota_locks.relation_cache_lock);
 
-				if (local_active_table_stat_map != NULL) continue;
+				if (local_table_stats_map != NULL) continue;
 
 				for (int i = -1; i < SEGCOUNT; i++)
 				{
@@ -1099,11 +1099,11 @@ calculate_table_disk_usage(HTAB *local_active_table_stat_map)
 				break;
 			}
 
-			if (local_active_table_stat_map != NULL)
+			if (local_table_stats_map != NULL)
 			{
 				bool                      active_tbl_found;
 				ActiveTableEntryCombined *active_table_entry = (ActiveTableEntryCombined *)hash_search(
-				        local_active_table_stat_map, &relOid, HASH_FIND, &active_tbl_found);
+				        local_table_stats_map, &relOid, HASH_FIND, &active_tbl_found);
 				/* skip to recalculate the tables which are not in active list */
 				if (active_tbl_found && active_table_entry != NULL)
 				{
@@ -1112,7 +1112,7 @@ calculate_table_disk_usage(HTAB *local_active_table_stat_map)
 			}
 
 			/* table size info doesn't need to flush at init quota model stage */
-			if (local_active_table_stat_map == NULL)
+			if (local_table_stats_map == NULL)
 			{
 				TableSizeEntryResetFlushFlag(tsentry, cur_segid);
 			}

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -981,7 +981,6 @@ calculate_table_disk_usage(bool is_init)
 	HASH_SEQ_STATUS iter;
 	List           *oidlist;
 	ListCell       *l;
-	DeleteArrays delete = {0};
 
 	/*
 	 * unset is_exist flag for tsentry in table_size_map this is used to
@@ -998,7 +997,7 @@ calculate_table_disk_usage(bool is_init)
 	 * calculate the file size for active table and update namespace_size_map
 	 * and role_size_map
 	 */
-	oidlist = get_rel_oid_list(is_init);
+	oidlist = get_rel_oid_list();
 
 	oidlist = merge_uncommitted_table_to_oidlist(oidlist);
 
@@ -1032,21 +1031,6 @@ calculate_table_disk_usage(bool is_init)
 			{
 				elog(WARNING, "cache lookup failed for relation %u", relOid);
 				LWLockRelease(diskquota_locks.relation_cache_lock);
-
-				if (!is_init) continue;
-
-				for (int i = -1; i < SEGCOUNT; i++)
-				{
-					delete.tableids = accumArrayResult(delete.tableids, ObjectIdGetDatum(relOid), false, OIDOID,
-					                                   CurrentMemoryContext);
-					delete.segids =
-					        accumArrayResult(delete.segids, Int16GetDatum(i), false, INT2OID, CurrentMemoryContext);
-
-					if (delete.tableids->nelems > SQL_MAX_VALUES_NUMBER)
-					{
-						delete_from_table_size_map(&delete);
-					}
-				}
 
 				continue;
 			}
@@ -1119,11 +1103,6 @@ calculate_table_disk_usage(bool is_init)
 		{
 			heap_freetuple(classTup);
 		}
-	}
-
-	if (delete.tableids)
-	{
-		delete_from_table_size_map(&delete);
 	}
 
 	list_free(oidlist);

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -220,7 +220,7 @@ static void transfer_table_for_quota(int64 totalsize, QuotaType type, Oid *old_k
 
 /* functions to refresh disk quota model*/
 static void refresh_disk_quota_usage(bool is_init);
-static void calculate_table_disk_usage(HTAB *local_table_stats_map);
+static void calculate_table_disk_usage(bool is_init);
 static void flush_to_table_size(void);
 static bool flush_local_reject_map(void);
 static void dispatch_rejectmap(const char *active_oids);
@@ -809,9 +809,8 @@ refresh_disk_quota_model(bool is_init)
 static void
 refresh_disk_quota_usage(bool is_init)
 {
-	volatile bool pushed_active_snap     = false;
-	volatile bool ret                    = true;
-	HTAB *volatile local_table_stats_map = NULL;
+	volatile bool  pushed_active_snap = false;
+	volatile bool  ret                = true;
 	StringInfoData active_oids;
 
 	StartTransactionCommand();
@@ -829,24 +828,11 @@ refresh_disk_quota_usage(bool is_init)
 		/*
 		 * initialization stage all the tables are active. later loop, only the
 		 * tables whose disk size changed will be treated as active
-		 *
-		 * local_table_stats_map only contains the active tables which belong
-		 * to the current database.
 		 */
-		if (!is_init)
-		{
-			HASHCTL ctl = {
-			        .keysize   = sizeof(Oid),
-			        .entrysize = sizeof(ActiveTableEntryCombined) + SEGCOUNT * sizeof(Size),
-			        .hcxt      = CurrentMemoryContext,
-			};
-			local_table_stats_map = diskquota_hash_create("local active table map with relfilenode info", 1024, &ctl,
-			                                              HASH_ELEM | HASH_CONTEXT, DISKQUOTA_OID_HASH);
-		}
-		gp_fetch_active_tables(&active_oids, local_table_stats_map);
+		gp_fetch_active_tables(is_init, &active_oids);
 		/* TODO: if we can skip the following steps when there is no active table */
 		/* recalculate the disk usage of table, schema and role */
-		calculate_table_disk_usage(local_table_stats_map);
+		calculate_table_disk_usage(is_init);
 		/* refresh quota_info_map */
 		refresh_quota_info_map();
 		/* flush local table_size_map to user table table_size */
@@ -874,7 +860,6 @@ refresh_disk_quota_usage(bool is_init)
 	}
 	PG_END_TRY();
 	if (active_oids.data) pfree(active_oids.data);
-	if (local_table_stats_map) hash_destroy(local_table_stats_map);
 	if (pushed_active_snap) PopActiveSnapshot();
 	if (ret)
 		CommitTransactionCommand();
@@ -926,7 +911,7 @@ get_tsentry(Oid tableid, int16 segid)
 
 	if (!table_size_map_found && tsentry != NULL)
 	{
-		Assert(TableSizeEntrySegidStart(tsentry) == segid);
+		// Assert(TableSizeEntrySegidStart(tsentry) == segid);
 		memset(tsentry->totalsize, 0, sizeof(tsentry->totalsize));
 		tsentry->owneroid      = InvalidOid;
 		tsentry->namespaceoid  = InvalidOid;
@@ -996,7 +981,7 @@ update_active_table_size(Oid tableid, int64 size, int16 segid, void *arg)
  */
 
 static void
-calculate_table_disk_usage(HTAB *local_table_stats_map)
+calculate_table_disk_usage(bool is_init)
 {
 	TableSizeEntry *tsentry = NULL;
 	Oid             relOid;
@@ -1020,7 +1005,7 @@ calculate_table_disk_usage(HTAB *local_table_stats_map)
 	 * calculate the file size for active table and update namespace_size_map
 	 * and role_size_map
 	 */
-	oidlist = get_rel_oid_list(local_table_stats_map == NULL);
+	oidlist = get_rel_oid_list(is_init);
 
 	oidlist = merge_uncommitted_table_to_oidlist(oidlist);
 
@@ -1055,7 +1040,7 @@ calculate_table_disk_usage(HTAB *local_table_stats_map)
 				elog(WARNING, "cache lookup failed for relation %u", relOid);
 				LWLockRelease(diskquota_locks.relation_cache_lock);
 
-				if (local_table_stats_map != NULL) continue;
+				if (!is_init) continue;
 
 				for (int i = -1; i < SEGCOUNT; i++)
 				{
@@ -1095,20 +1080,8 @@ calculate_table_disk_usage(HTAB *local_table_stats_map)
 				break;
 			}
 
-			if (local_table_stats_map != NULL)
-			{
-				bool                      active_tbl_found;
-				ActiveTableEntryCombined *active_table_entry = (ActiveTableEntryCombined *)hash_search(
-				        local_table_stats_map, &relOid, HASH_FIND, &active_tbl_found);
-				/* skip to recalculate the tables which are not in active list */
-				if (active_tbl_found && active_table_entry != NULL)
-				{
-					update_active_table_size(relOid, active_table_entry->tablesize[cur_segid + 1], cur_segid, tsentry);
-				}
-			}
-
 			/* table size info doesn't need to flush at init quota model stage */
-			if (local_table_stats_map == NULL)
+			if (is_init)
 			{
 				TableSizeEntryResetFlushFlag(tsentry, cur_segid);
 			}

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -220,7 +220,7 @@ static void transfer_table_for_quota(int64 totalsize, QuotaType type, Oid *old_k
 
 /* functions to refresh disk quota model*/
 static void refresh_disk_quota_usage(bool is_init);
-static void calculate_table_disk_usage(bool is_init);
+static void calculate_schema_and_role_disk_usage(bool is_init);
 static void flush_to_table_size(void);
 static bool flush_local_reject_map(void);
 static void dispatch_rejectmap(const char *active_oids);
@@ -832,8 +832,8 @@ refresh_disk_quota_usage(bool is_init)
 		gp_fetch_active_tables(is_init, &active_oids);
 		bool hasActiveTable = (active_oids.len > 0);
 		/* TODO: if we can skip the following steps when there is no active table */
-		/* recalculate the disk usage of table, schema and role */
-		calculate_table_disk_usage(is_init);
+		/* recalculate the disk usage of schema and role */
+		calculate_schema_and_role_disk_usage(is_init);
 		/* refresh quota_info_map */
 		refresh_quota_info_map();
 		/* flush local table_size_map to user table table_size */
@@ -969,6 +969,7 @@ calculate_active_table_disk_usage(Oid oid, int64 size, int16 segid)
 }
 
 /*
+ *  Recalculate the schema and role disk usage.
  *  Detect the removed table if it's no longer in pg_class.
  *  If change happens, no matter size change or owner change,
  *  update namespace_size_map and role_size_map correspondingly.
@@ -977,7 +978,7 @@ calculate_active_table_disk_usage(Oid oid, int64 size, int16 segid)
  */
 
 static void
-calculate_table_disk_usage(bool is_init)
+calculate_schema_and_role_disk_usage(bool is_init)
 {
 	TableSizeEntry *tsentry = NULL;
 	Oid             relOid;

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -923,6 +923,10 @@ get_table_size_map_entry(Oid oid, int16 segid)
 	return tsentry;
 }
 
+/*
+ *  Incremental way to update the disk quota of every active tables.
+ *  Recalculate the table's disk usage when it's an active table.
+ */
 void
 calculate_active_table_disk_usage(Oid oid, int64 size, int16 segid)
 {

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -252,9 +252,6 @@ typedef struct
 	ArrayBuildState *segids;
 } UpdateArrays;
 
-static void delete_from_table_size_map(DeleteArrays *arrays);
-static void update_table_size_map(UpdateArrays *arrays);
-
 /* add a new entry quota or update the old entry quota */
 static void
 update_size_for_quota(int64 size, QuotaType type, Oid *keys, int16 segid)

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -1387,7 +1387,6 @@ dispatch_rejectmap(StringInfoData active_oids)
 {
 	HASH_SEQ_STATUS       hash_seq;
 	GlobalRejectMapEntry *rejectmap_entry;
-	int                   num_entries, count = 0;
 	CdbPgResults          cdb_pgresults = {NULL, 0};
 	StringInfoData        rows;
 	StringInfoData        sql;
@@ -1396,15 +1395,13 @@ dispatch_rejectmap(StringInfoData active_oids)
 	initStringInfo(&sql);
 
 	LWLockAcquire(diskquota_locks.reject_map_lock, LW_SHARED);
-	num_entries = hash_get_num_entries(disk_quota_reject_map);
 	hash_seq_init(&hash_seq, disk_quota_reject_map);
 	while ((rejectmap_entry = hash_seq_search(&hash_seq)) != NULL)
 	{
+		if (rows.len > 0) appendStringInfoString(&rows, ",");
 		appendStringInfo(&rows, "ROW(%d, %d, %d, %d, %s)", rejectmap_entry->keyitem.targetoid,
 		                 rejectmap_entry->keyitem.databaseoid, rejectmap_entry->keyitem.tablespaceoid,
 		                 rejectmap_entry->keyitem.targettype, rejectmap_entry->segexceeded ? "true" : "false");
-
-		if (++count != num_entries) appendStringInfo(&rows, ",");
 	}
 	LWLockRelease(diskquota_locks.reject_map_lock);
 
@@ -1413,10 +1410,11 @@ dispatch_rejectmap(StringInfoData active_oids)
 	                 "ARRAY[%s]::diskquota.rejectmap_entry[], "
 	                 "ARRAY[%s]::oid[])",
 	                 rows.data, active_oids.data);
-	CdbDispatchCommand(sql.data, DF_NONE, &cdb_pgresults);
-
 	pfree(rows.data);
 	pfree(sql.data);
+
+	CdbDispatchCommand(sql.data, DF_NONE, &cdb_pgresults);
+
 	cdbdisp_clearCdbPgResults(&cdb_pgresults);
 }
 

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -930,9 +930,9 @@ get_tsentry(Oid tableid, int16 segid)
 }
 
 void
-update_active_table_size(Oid tableid, int64 size, int16 segid, void *arg)
+update_active_table_size(Oid tableid, int64 size, int16 segid)
 {
-	TableSizeEntry *tsentry = arg != NULL ? arg : get_tsentry(tableid, segid);
+	TableSizeEntry *tsentry = get_tsentry(tableid, segid);
 
 	if (tsentry == NULL)
 	{

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -911,7 +911,6 @@ get_tsentry(Oid tableid, int16 segid)
 
 	if (!table_size_map_found && tsentry != NULL)
 	{
-		// Assert(TableSizeEntrySegidStart(tsentry) == segid);
 		memset(tsentry->totalsize, 0, sizeof(tsentry->totalsize));
 		tsentry->owneroid      = InvalidOid;
 		tsentry->namespaceoid  = InvalidOid;
@@ -1380,7 +1379,6 @@ dispatch_rejectmap(const char *active_oids)
 	                 "ARRAY[%s]::diskquota.rejectmap_entry[], "
 	                 "ARRAY[%s]::oid[])",
 	                 rows.data, active_oids);
-
 	CdbDispatchCommand(sql.data, DF_NONE, &cdb_pgresults);
 
 	pfree(rows.data);

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -220,10 +220,10 @@ static void transfer_table_for_quota(int64 totalsize, QuotaType type, Oid *old_k
 
 /* functions to refresh disk quota model*/
 static void refresh_disk_quota_usage(bool is_init);
-static void calculate_table_disk_usage(bool is_init, HTAB *local_active_table_stat_map);
+static void calculate_table_disk_usage(HTAB *local_active_table_stat_map);
 static void flush_to_table_size(void);
 static bool flush_local_reject_map(void);
-static void dispatch_rejectmap(HTAB *local_active_table_stat_map);
+static void dispatch_rejectmap(StringInfoData active_oids);
 static bool load_quotas(void);
 static void do_load_quotas(void);
 
@@ -812,6 +812,7 @@ refresh_disk_quota_usage(bool is_init)
 	volatile bool pushed_active_snap           = false;
 	volatile bool ret                          = true;
 	HTAB *volatile local_active_table_stat_map = NULL;
+	StringInfoData volatile active_oids        = {0};
 
 	StartTransactionCommand();
 
@@ -831,11 +832,20 @@ refresh_disk_quota_usage(bool is_init)
 		 * local_active_table_stat_map only contains the active tables which belong
 		 * to the current database.
 		 */
-		local_active_table_stat_map = gp_fetch_active_tables(is_init);
-		bool hasActiveTable         = (hash_get_num_entries(local_active_table_stat_map) != 0);
+		if (!is_init)
+		{
+			HASHCTL ctl = {
+			        .keysize   = sizeof(Oid),
+			        .entrysize = sizeof(ActiveTableEntryCombined) + SEGCOUNT * sizeof(Size),
+			        .hcxt      = CurrentMemoryContext,
+			};
+			local_active_table_stat_map = diskquota_hash_create("local active table map with relfilenode info", 1024,
+			                                                    &ctl, HASH_ELEM | HASH_CONTEXT, DISKQUOTA_OID_HASH);
+		}
+		active_oids = gp_fetch_active_tables(local_active_table_stat_map);
 		/* TODO: if we can skip the following steps when there is no active table */
 		/* recalculate the disk usage of table, schema and role */
-		calculate_table_disk_usage(is_init, local_active_table_stat_map);
+		calculate_table_disk_usage(local_active_table_stat_map);
 		/* refresh quota_info_map */
 		refresh_quota_info_map();
 		/* flush local table_size_map to user table table_size */
@@ -848,8 +858,8 @@ refresh_disk_quota_usage(bool is_init)
 		 * Otherwise, only when the rejectmap is changed or the active_table_list is
 		 * not empty the rejectmap should be dispatched to segments.
 		 */
-		if (is_init || (diskquota_hardlimit && (reject_map_changed || hasActiveTable)))
-			dispatch_rejectmap(local_active_table_stat_map);
+		if (is_init || (diskquota_hardlimit && (reject_map_changed || active_oids.len > 0)))
+			dispatch_rejectmap(active_oids);
 	}
 	PG_CATCH();
 	{
@@ -862,6 +872,7 @@ refresh_disk_quota_usage(bool is_init)
 		RESUME_INTERRUPTS();
 	}
 	PG_END_TRY();
+	if (active_oids.data) pfree(active_oids.data);
 	if (local_active_table_stat_map) hash_destroy(local_active_table_stat_map);
 	if (pushed_active_snap) PopActiveSnapshot();
 	if (ret)
@@ -900,6 +911,81 @@ merge_uncommitted_table_to_oidlist(List *oidlist)
 	return oidlist;
 }
 
+static TableSizeEntry *
+get_tsentry(Oid tableid, int16 segid)
+{
+	bool              table_size_map_found;
+	TableSizeEntryKey key = {
+	        .reloid = tableid,
+	        .id     = TableSizeEntryId(segid),
+	};
+	HASHACTION      action  = check_hash_fullness(table_size_map, MAX_NUM_TABLE_SIZE_ENTRIES, table_size_map_warning,
+	                                              table_size_map_last_overflow_report);
+	TableSizeEntry *tsentry = hash_search(table_size_map, &key, action, &table_size_map_found);
+
+	if (!table_size_map_found && tsentry != NULL)
+	{
+		Assert(TableSizeEntrySegidStart(tsentry) == segid);
+		memset(tsentry->totalsize, 0, sizeof(tsentry->totalsize));
+		tsentry->owneroid      = InvalidOid;
+		tsentry->namespaceoid  = InvalidOid;
+		tsentry->tablespaceoid = InvalidOid;
+		tsentry->flag          = 0;
+
+		int seg_st = TableSizeEntrySegidStart(tsentry);
+		int seg_ed = TableSizeEntrySegidEnd(tsentry);
+		for (int j = seg_st; j < seg_ed; j++) TableSizeEntrySetFlushFlag(tsentry, j);
+	}
+
+	/* mark tsentry is_exist */
+	if (tsentry) set_table_size_entry_flag(tsentry, TABLE_EXIST);
+
+	return tsentry;
+}
+
+void
+update_active_table_size(Oid tableid, int64 size, int16 segid, void *arg)
+{
+	TableSizeEntry *tsentry = arg != NULL ? arg : get_tsentry(tableid, segid);
+
+	if (tsentry == NULL)
+	{
+		/*
+		 * Too many tables have been added to the table_size_map, to avoid diskquota using
+		 * too much share memory, just return the function. The diskquota won't work correctly
+		 * anymore.
+		 */
+		return;
+	}
+
+	if (segid == -1)
+	{
+		/* pretend process as utility mode, and append the table size on master */
+		Gp_role = GP_ROLE_UTILITY;
+
+		/* when segid is -1, the size is the sum of size of master and all segments */
+		size += calculate_table_size(tableid);
+
+		Gp_role = GP_ROLE_DISPATCH;
+	}
+
+	/* firstly calculate the updated total size of a table */
+	int64 updated_total_size = size - TableSizeEntryGetSize(tsentry, segid);
+
+	/* update the table_size entry */
+	TableSizeEntrySetSize(tsentry, segid, size);
+	TableSizeEntrySetFlushFlag(tsentry, segid);
+
+	/* update the disk usage, there may be entries in the map whose keys are InvlidOid as the tsentry does
+	 * not exist in the table_size_map */
+	update_size_for_quota(updated_total_size, NAMESPACE_QUOTA, (Oid[]){tsentry->namespaceoid}, segid);
+	update_size_for_quota(updated_total_size, ROLE_QUOTA, (Oid[]){tsentry->owneroid}, segid);
+	update_size_for_quota(updated_total_size, ROLE_TABLESPACE_QUOTA, (Oid[]){tsentry->owneroid, tsentry->tablespaceoid},
+	                      segid);
+	update_size_for_quota(updated_total_size, NAMESPACE_TABLESPACE_QUOTA,
+	                      (Oid[]){tsentry->namespaceoid, tsentry->tablespaceoid}, segid);
+}
+
 /*
  *  Incremental way to update the disk quota of every database objects
  *  Recalculate the table's disk usage when it's a new table or active table.
@@ -911,18 +997,13 @@ merge_uncommitted_table_to_oidlist(List *oidlist)
  */
 
 static void
-calculate_table_disk_usage(bool is_init, HTAB *local_active_table_stat_map)
+calculate_table_disk_usage(HTAB *local_active_table_stat_map)
 {
-	bool                      table_size_map_found;
-	bool                      active_tbl_found;
-	int64                     updated_total_size;
-	TableSizeEntry           *tsentry = NULL;
-	Oid                       relOid;
-	HASH_SEQ_STATUS           iter;
-	ActiveTableEntryCombined *active_table_entry;
-	TableSizeEntryKey         key;
-	List                     *oidlist;
-	ListCell                 *l;
+	TableSizeEntry *tsentry = NULL;
+	Oid             relOid;
+	HASH_SEQ_STATUS iter;
+	List           *oidlist;
+	ListCell       *l;
 	DeleteArrays delete = {0};
 
 	/*
@@ -940,7 +1021,7 @@ calculate_table_disk_usage(bool is_init, HTAB *local_active_table_stat_map)
 	 * calculate the file size for active table and update namespace_size_map
 	 * and role_size_map
 	 */
-	oidlist = get_rel_oid_list(is_init);
+	oidlist = get_rel_oid_list(local_active_table_stat_map == NULL);
 
 	oidlist = merge_uncommitted_table_to_oidlist(oidlist);
 
@@ -975,7 +1056,7 @@ calculate_table_disk_usage(bool is_init, HTAB *local_active_table_stat_map)
 				elog(WARNING, "cache lookup failed for relation %u", relOid);
 				LWLockRelease(diskquota_locks.relation_cache_lock);
 
-				if (!is_init) continue;
+				if (local_active_table_stat_map != NULL) continue;
 
 				for (int i = -1; i < SEGCOUNT; i++)
 				{
@@ -1005,74 +1086,32 @@ calculate_table_disk_usage(bool is_init, HTAB *local_active_table_stat_map)
 		 */
 		for (int cur_segid = -1; cur_segid < SEGCOUNT; cur_segid++)
 		{
-			key.reloid = relOid;
-			key.id     = TableSizeEntryId(cur_segid);
+			tsentry = get_tsentry(relOid, cur_segid);
 
-			HASHACTION action = check_hash_fullness(table_size_map, MAX_NUM_TABLE_SIZE_ENTRIES, table_size_map_warning,
-			                                        table_size_map_last_overflow_report);
-			tsentry           = hash_search(table_size_map, &key, action, &table_size_map_found);
-
-			if (!table_size_map_found)
+			if (tsentry == NULL)
 			{
-				if (tsentry == NULL)
-				{
-					/* Too many tables have been added to the table_size_map, to avoid diskquota using
-					   too much share memory, just quit the loop. The diskquota won't work correctly
-					   anymore. */
-					break;
-				}
-
-				tsentry->key.reloid = relOid;
-				tsentry->key.id     = key.id;
-				Assert(TableSizeEntrySegidStart(tsentry) == cur_segid);
-				memset(tsentry->totalsize, 0, sizeof(tsentry->totalsize));
-				tsentry->owneroid      = InvalidOid;
-				tsentry->namespaceoid  = InvalidOid;
-				tsentry->tablespaceoid = InvalidOid;
-				tsentry->flag          = 0;
-
-				int seg_st = TableSizeEntrySegidStart(tsentry);
-				int seg_ed = TableSizeEntrySegidEnd(tsentry);
-				for (int j = seg_st; j < seg_ed; j++) TableSizeEntrySetFlushFlag(tsentry, j);
+				/*
+				 * Too many tables have been added to the table_size_map, to avoid diskquota using
+				 * too much share memory, just quit the loop. The diskquota won't work correctly
+				 * anymore.
+				 */
+				break;
 			}
 
-			/* mark tsentry is_exist */
-			if (tsentry) set_table_size_entry_flag(tsentry, TABLE_EXIST);
-			active_table_entry = (ActiveTableEntryCombined *)hash_search(local_active_table_stat_map, &relOid,
-			                                                             HASH_FIND, &active_tbl_found);
-
-			/* skip to recalculate the tables which are not in active list */
-			if (active_tbl_found)
+			if (local_active_table_stat_map != NULL)
 			{
-				if (cur_segid == -1)
+				bool                      active_tbl_found;
+				ActiveTableEntryCombined *active_table_entry = (ActiveTableEntryCombined *)hash_search(
+				        local_active_table_stat_map, &relOid, HASH_FIND, &active_tbl_found);
+				/* skip to recalculate the tables which are not in active list */
+				if (active_tbl_found && active_table_entry != NULL)
 				{
-					/* pretend process as utility mode, and append the table size on master */
-					Gp_role = GP_ROLE_UTILITY;
-
-					/* when cur_segid is -1, the tablesize is the sum of tablesize of master and all segments */
-					active_table_entry->tablesize[0] += calculate_table_size(relOid);
-
-					Gp_role = GP_ROLE_DISPATCH;
+					update_active_table_size(relOid, active_table_entry->tablesize[cur_segid + 1], cur_segid, tsentry);
 				}
-				/* firstly calculate the updated total size of a table */
-				updated_total_size =
-				        active_table_entry->tablesize[cur_segid + 1] - TableSizeEntryGetSize(tsentry, cur_segid);
-
-				/* update the table_size entry */
-				TableSizeEntrySetSize(tsentry, cur_segid, active_table_entry->tablesize[cur_segid + 1]);
-				TableSizeEntrySetFlushFlag(tsentry, cur_segid);
-
-				/* update the disk usage, there may be entries in the map whose keys are InvlidOid as the tsentry does
-				 * not exist in the table_size_map */
-				update_size_for_quota(updated_total_size, NAMESPACE_QUOTA, (Oid[]){tsentry->namespaceoid}, cur_segid);
-				update_size_for_quota(updated_total_size, ROLE_QUOTA, (Oid[]){tsentry->owneroid}, cur_segid);
-				update_size_for_quota(updated_total_size, ROLE_TABLESPACE_QUOTA,
-				                      (Oid[]){tsentry->owneroid, tsentry->tablespaceoid}, cur_segid);
-				update_size_for_quota(updated_total_size, NAMESPACE_TABLESPACE_QUOTA,
-				                      (Oid[]){tsentry->namespaceoid, tsentry->tablespaceoid}, cur_segid);
 			}
+
 			/* table size info doesn't need to flush at init quota model stage */
-			if (is_init)
+			if (local_active_table_stat_map == NULL)
 			{
 				TableSizeEntryResetFlushFlag(tsentry, cur_segid);
 			}
@@ -1344,19 +1383,16 @@ flush_local_reject_map(void)
  * Dispatch rejectmap to segment servers.
  */
 static void
-dispatch_rejectmap(HTAB *local_active_table_stat_map)
+dispatch_rejectmap(StringInfoData active_oids)
 {
-	HASH_SEQ_STATUS           hash_seq;
-	GlobalRejectMapEntry     *rejectmap_entry;
-	ActiveTableEntryCombined *active_table_entry;
-	int                       num_entries, count = 0;
-	CdbPgResults              cdb_pgresults = {NULL, 0};
-	StringInfoData            rows;
-	StringInfoData            active_oids;
-	StringInfoData            sql;
+	HASH_SEQ_STATUS       hash_seq;
+	GlobalRejectMapEntry *rejectmap_entry;
+	int                   num_entries, count = 0;
+	CdbPgResults          cdb_pgresults = {NULL, 0};
+	StringInfoData        rows;
+	StringInfoData        sql;
 
 	initStringInfo(&rows);
-	initStringInfo(&active_oids);
 	initStringInfo(&sql);
 
 	LWLockAcquire(diskquota_locks.reject_map_lock, LW_SHARED);
@@ -1372,16 +1408,6 @@ dispatch_rejectmap(HTAB *local_active_table_stat_map)
 	}
 	LWLockRelease(diskquota_locks.reject_map_lock);
 
-	count       = 0;
-	num_entries = hash_get_num_entries(local_active_table_stat_map);
-	hash_seq_init(&hash_seq, local_active_table_stat_map);
-	while ((active_table_entry = hash_seq_search(&hash_seq)) != NULL)
-	{
-		appendStringInfo(&active_oids, "%d", active_table_entry->reloid);
-
-		if (++count != num_entries) appendStringInfo(&active_oids, ",");
-	}
-
 	appendStringInfo(&sql,
 	                 "select diskquota.refresh_rejectmap("
 	                 "ARRAY[%s]::diskquota.rejectmap_entry[], "
@@ -1390,7 +1416,6 @@ dispatch_rejectmap(HTAB *local_active_table_stat_map)
 	CdbDispatchCommand(sql.data, DF_NONE, &cdb_pgresults);
 
 	pfree(rows.data);
-	pfree(active_oids.data);
 	pfree(sql.data);
 	cdbdisp_clearCdbPgResults(&cdb_pgresults);
 }

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -220,7 +220,7 @@ static void transfer_table_for_quota(int64 totalsize, QuotaType type, Oid *old_k
 
 /* functions to refresh disk quota model*/
 static void refresh_disk_quota_usage(bool is_init);
-static void calculate_schema_and_role_disk_usage(bool is_init);
+static void track_namespace_owner_tablespace_changes(bool is_init);
 static void flush_to_table_size(void);
 static bool flush_local_reject_map(void);
 static void dispatch_rejectmap(const char *active_oids);
@@ -832,8 +832,8 @@ refresh_disk_quota_usage(bool is_init)
 		gp_fetch_active_tables(is_init, &active_oids);
 		bool hasActiveTable = (active_oids.len > 0);
 		/* TODO: if we can skip the following steps when there is no active table */
-		/* recalculate the disk usage of schema and role */
-		calculate_schema_and_role_disk_usage(is_init);
+		/* Recalculate the namespace, owner and tablespace disk usage */
+		track_namespace_owner_tablespace_changes(is_init);
 		/* refresh quota_info_map */
 		refresh_quota_info_map();
 		/* flush local table_size_map to user table table_size */
@@ -969,16 +969,15 @@ calculate_active_table_disk_usage(Oid oid, int64 size, int16 segid)
 }
 
 /*
- *  Recalculate the schema and role disk usage.
+ *  Recalculate the namespace, owner and tablespace disk usage.
  *  Detect the removed table if it's no longer in pg_class.
- *  If change happens, no matter size change or owner change,
- *  update namespace_size_map and role_size_map correspondingly.
- *  Parameter 'is_init' set to true at initialization stage to fetch tables
- *  size from table table_size
+ *  If change happens, no matter size change or namespace change or
+ *  owner change or tablespace change, update quota_info_map.
+ *  Parameter 'is_init' set to true at initialization stage.
  */
 
 static void
-calculate_schema_and_role_disk_usage(bool is_init)
+track_namespace_owner_tablespace_changes(bool is_init)
 {
 	TableSizeEntry *tsentry = NULL;
 	Oid             relOid;
@@ -998,8 +997,7 @@ calculate_schema_and_role_disk_usage(bool is_init)
 
 	/*
 	 * scan pg_class to detect table event: drop, reset schema, reset owner.
-	 * calculate the file size for active table and update namespace_size_map
-	 * and role_size_map
+	 * calculate the file size for active table and update quota_info_map
 	 */
 	oidlist = get_rel_oid_list();
 

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -223,7 +223,7 @@ static void refresh_disk_quota_usage(bool is_init);
 static void calculate_table_disk_usage(HTAB *local_active_table_stat_map);
 static void flush_to_table_size(void);
 static bool flush_local_reject_map(void);
-static void dispatch_rejectmap(StringInfoData active_oids);
+static void dispatch_rejectmap(StringInfoData *active_oids);
 static bool load_quotas(void);
 static void do_load_quotas(void);
 
@@ -812,9 +812,10 @@ refresh_disk_quota_usage(bool is_init)
 	volatile bool pushed_active_snap           = false;
 	volatile bool ret                          = true;
 	HTAB *volatile local_active_table_stat_map = NULL;
-	StringInfoData volatile active_oids        = {0};
+	StringInfoData active_oids;
 
 	StartTransactionCommand();
+	initStringInfo(&active_oids);
 
 	/*
 	 * Cache Errors during SPI functions, for example a segment may be down
@@ -842,7 +843,7 @@ refresh_disk_quota_usage(bool is_init)
 			local_active_table_stat_map = diskquota_hash_create("local active table map with relfilenode info", 1024,
 			                                                    &ctl, HASH_ELEM | HASH_CONTEXT, DISKQUOTA_OID_HASH);
 		}
-		active_oids = gp_fetch_active_tables(local_active_table_stat_map);
+		gp_fetch_active_tables(&active_oids, local_active_table_stat_map);
 		/* TODO: if we can skip the following steps when there is no active table */
 		/* recalculate the disk usage of table, schema and role */
 		calculate_table_disk_usage(local_active_table_stat_map);
@@ -859,7 +860,7 @@ refresh_disk_quota_usage(bool is_init)
 		 * not empty the rejectmap should be dispatched to segments.
 		 */
 		if (is_init || (diskquota_hardlimit && (reject_map_changed || active_oids.len > 0)))
-			dispatch_rejectmap(active_oids);
+			dispatch_rejectmap(&active_oids);
 	}
 	PG_CATCH();
 	{
@@ -1383,7 +1384,7 @@ flush_local_reject_map(void)
  * Dispatch rejectmap to segment servers.
  */
 static void
-dispatch_rejectmap(StringInfoData active_oids)
+dispatch_rejectmap(StringInfoData *active_oids)
 {
 	HASH_SEQ_STATUS       hash_seq;
 	GlobalRejectMapEntry *rejectmap_entry;
@@ -1409,7 +1410,7 @@ dispatch_rejectmap(StringInfoData active_oids)
 	                 "select diskquota.refresh_rejectmap("
 	                 "ARRAY[%s]::diskquota.rejectmap_entry[], "
 	                 "ARRAY[%s]::oid[])",
-	                 rows.data, active_oids.data);
+	                 rows.data, active_oids->data);
 	pfree(rows.data);
 	pfree(sql.data);
 

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -969,8 +969,6 @@ calculate_active_table_disk_usage(Oid oid, int64 size, int16 segid)
 }
 
 /*
- *  Incremental way to update the disk quota of every database objects
- *  Recalculate the table's disk usage when it's a new table or active table.
  *  Detect the removed table if it's no longer in pg_class.
  *  If change happens, no matter size change or owner change,
  *  update namespace_size_map and role_size_map correspondingly.

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -223,7 +223,7 @@ static void refresh_disk_quota_usage(bool is_init);
 static void calculate_table_disk_usage(HTAB *local_table_stats_map);
 static void flush_to_table_size(void);
 static bool flush_local_reject_map(void);
-static void dispatch_rejectmap(StringInfoData *active_oids);
+static void dispatch_rejectmap(const char *active_oids);
 static bool load_quotas(void);
 static void do_load_quotas(void);
 
@@ -860,7 +860,7 @@ refresh_disk_quota_usage(bool is_init)
 		 * not empty the rejectmap should be dispatched to segments.
 		 */
 		if (is_init || (diskquota_hardlimit && (reject_map_changed || active_oids.len > 0)))
-			dispatch_rejectmap(&active_oids);
+			dispatch_rejectmap(active_oids.data);
 	}
 	PG_CATCH();
 	{
@@ -1384,7 +1384,7 @@ flush_local_reject_map(void)
  * Dispatch rejectmap to segment servers.
  */
 static void
-dispatch_rejectmap(StringInfoData *active_oids)
+dispatch_rejectmap(const char *active_oids)
 {
 	HASH_SEQ_STATUS       hash_seq;
 	GlobalRejectMapEntry *rejectmap_entry;
@@ -1410,7 +1410,7 @@ dispatch_rejectmap(StringInfoData *active_oids)
 	                 "select diskquota.refresh_rejectmap("
 	                 "ARRAY[%s]::diskquota.rejectmap_entry[], "
 	                 "ARRAY[%s]::oid[])",
-	                 rows.data, active_oids->data);
+	                 rows.data, active_oids);
 	pfree(rows.data);
 	pfree(sql.data);
 

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -1407,11 +1407,11 @@ dispatch_rejectmap(const char *active_oids)
 	                 "ARRAY[%s]::diskquota.rejectmap_entry[], "
 	                 "ARRAY[%s]::oid[])",
 	                 rows.data, active_oids);
-	pfree(rows.data);
-	pfree(sql.data);
 
 	CdbDispatchCommand(sql.data, DF_NONE, &cdb_pgresults);
 
+	pfree(rows.data);
+	pfree(sql.data);
 	cdbdisp_clearCdbPgResults(&cdb_pgresults);
 }
 

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -924,7 +924,7 @@ get_table_size_map_entry(Oid oid, int16 segid)
 }
 
 void
-update_active_table_size(Oid oid, int64 size, int16 segid)
+calculate_active_table_disk_usage(Oid oid, int64 size, int16 segid)
 {
 	TableSizeEntry *tsentry = get_table_size_map_entry(oid, segid);
 


### PR DESCRIPTION
Refactor diskquota local hashmap with active tables

diskquota used a local hashmap local_table_stats_map in the
gp_fetch_active_tables function. During initialization, it loaded all the
information from the table with the sizes diskquota.table_size into it using
the load_table_size function. And during normal operation, diskquota loaded
information about active tables with sizes from segments into this local
hashmap using the pull_active_list_from_seg, convert_map_to_string, and
pull_active_table_size_from_seg functions. This led to increased memory
consumption, especially during initialization, since with a large number of
active tables (and all tables were considered active during initialization),
the size of this local hashmap local_table_stats_map was quite large. This
local_table_stats_map was then used in the calculate_table_disk_usage function
to calculate the sizes of active tables, and in the dispatch_rejectmap function
to dispatch active tables to segments.

This patch completely gets rid of the local_table_stats_map local hashmap,
calculating the sizes of active tables directly when receiving results in the
load_table_size and pull_active_table_size_from_seg functions, simultaneously
filling in the active_oids text list of active tables, which is then passed to
the dispatch_rejectmap function. The new get_table_size_map_entry and
update_active_table_size functions are extracted parts of the
calculate_table_disk_usage function code related to active tables. The
invalidation logic during initialization 14b861d has been completely reverted
because it is already covered by the current changes.

---
It is easier to view the changes with the "Hide whitespace" option enabled.