### PR TITLE
Update diskquota to support external Orca

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ create database diskquota;
 3. Enable diskquota as preload library 
 ```
 # enable diskquota in preload library.
-gpconfig -c shared_preload_libraries -v 'diskquota-<major.minor>'
+gpconfig -c shared_preload_libraries -v "$(psql -At -c "SELECT array_to_string(array_append(string_to_array(current_setting('shared_preload_libraries'), ','), 'diskquota-<major.minor>'), ',')" postgres)"
 # restart database.
 gpstop -ar
 ```

--- a/tests/isolation2/expected/config.out
+++ b/tests/isolation2/expected/config.out
@@ -1,5 +1,5 @@
 
-!\retcode gpconfig -c shared_preload_libraries -v $(./data/current_binary_name);
+!\retcode gpconfig -c shared_preload_libraries -v "$(psql -At -c "SELECT array_to_string(array_append(string_to_array(regexp_replace(current_setting('shared_preload_libraries'), '(,{0,1})diskquota(.*)\.so', ''), ','), '$(./data/current_binary_name)'), ',')" postgres)";
 (exited with code 0)
 !\retcode gpconfig -c diskquota.naptime -v 0 --skipvalidation;
 (exited with code 0)

--- a/tests/isolation2/sql/config.sql
+++ b/tests/isolation2/sql/config.sql
@@ -2,7 +2,7 @@
 CREATE DATABASE diskquota;
 --end_ignore
 
-!\retcode gpconfig -c shared_preload_libraries -v $(./data/current_binary_name);
+!\retcode gpconfig -c shared_preload_libraries -v "$(psql -At -c "SELECT array_to_string(array_append(string_to_array(regexp_replace(current_setting('shared_preload_libraries'), '(,{0,1})diskquota(.*)\.so', ''), ','), '$(./data/current_binary_name)'), ',')" postgres)";
 !\retcode gpconfig -c diskquota.naptime -v 0 --skipvalidation;
 !\retcode gpconfig -c max_worker_processes -v 20 --skipvalidation;
 

--- a/tests/regress/expected/test_ctas_no_preload_lib.out
+++ b/tests/regress/expected/test_ctas_no_preload_lib.out
@@ -1,4 +1,4 @@
-\! gpconfig -c shared_preload_libraries -v '' > /dev/null 
+\! gpconfig -c shared_preload_libraries -v "$(psql -At -c "SELECT regexp_replace(current_setting('shared_preload_libraries'), '(,{0,1})diskquota(.*)\.so', '')" postgres)" > /dev/null
 \! gpstop -far > /dev/null
 \c
 CREATE ROLE test SUPERUSER;
@@ -6,7 +6,7 @@ SET ROLE test;
 -- Create table with diskquota disabled
 CREATE TABLE t_without_diskquota (i) AS SELECT generate_series(1, 100000)
 DISTRIBUTED BY (i);
-\! gpconfig -c shared_preload_libraries -v $(./data/current_binary_name) > /dev/null
+\! gpconfig -c shared_preload_libraries -v "$(psql -At -c "SELECT array_to_string(array_append(string_to_array(current_setting('shared_preload_libraries'), ','), '$(./data/current_binary_name)'), ',')" postgres)" > /dev/null
 \! gpstop -far > /dev/null
 \c
 SET ROLE test;

--- a/tests/regress/sql/config.sql
+++ b/tests/regress/sql/config.sql
@@ -1,7 +1,7 @@
 --start_ignore
 CREATE DATABASE diskquota;
 
-\! gpconfig -c shared_preload_libraries -v $(./data/current_binary_name);
+\! gpconfig -c shared_preload_libraries -v "$(psql -At -c "SELECT array_to_string(array_append(string_to_array(regexp_replace(current_setting('shared_preload_libraries'), '(,{0,1})diskquota(.*)\.so', ''), ','), '$(./data/current_binary_name)'), ',')" postgres)";
 \! gpconfig -c diskquota.naptime -v 0 --skipvalidation
 \! gpconfig -c max_worker_processes -v 20 --skipvalidation
 \! gpconfig -c diskquota.hard_limit -v "off" --skipvalidation

--- a/tests/regress/sql/test_ctas_no_preload_lib.sql
+++ b/tests/regress/sql/test_ctas_no_preload_lib.sql
@@ -1,4 +1,4 @@
-\! gpconfig -c shared_preload_libraries -v '' > /dev/null 
+\! gpconfig -c shared_preload_libraries -v "$(psql -At -c "SELECT regexp_replace(current_setting('shared_preload_libraries'), '(,{0,1})diskquota(.*)\.so', '')" postgres)" > /dev/null
 \! gpstop -far > /dev/null
 \c
 
@@ -10,7 +10,7 @@ SET ROLE test;
 CREATE TABLE t_without_diskquota (i) AS SELECT generate_series(1, 100000)
 DISTRIBUTED BY (i);
 
-\! gpconfig -c shared_preload_libraries -v $(./data/current_binary_name) > /dev/null
+\! gpconfig -c shared_preload_libraries -v "$(psql -At -c "SELECT array_to_string(array_append(string_to_array(current_setting('shared_preload_libraries'), ','), '$(./data/current_binary_name)'), ',')" postgres)" > /dev/null
 \! gpstop -far > /dev/null
 \c
 


### PR DESCRIPTION
Update diskquota to support external Orca

Problem description:
diskquota tests require setting of 'shared_preload_libraries' with a proper
version of diskquota lib. But, when setting 'shared_preload_libraries', previous
value of 'shared_preload_libraries' was cleared out. Therefore, in case of GPDB
with external Orca (when Orca is a shared library), Orca was disabled during
testing. As Orca is an essential part of GPDB, testing diskquota with disabled
Orca is not correct.

Fix:
In setting of 'shared_preload_libraries', read current value, and add or remove
only diskquota substring. When removing, use `regexp_replace()` function, as
diskquota lib name may contain its version. Also, use `regexp_replace()` in 
config.sql to clear out previous value of diskquota lib from
'shared_preload_libraries', which could have left from the preceding test run.

Plus, README file is updated with a proper command sample for 'gpconfig'.


-----------------------------

To launch tests with GPDB with external Orca you may use `hub.adsw.io/library/gpdb7_u22:feature_ADBDEV-6552` with below steps:

```
docker run --rm -it \
       -v /tmp/diskquota_artifacts:/home/gpadmin/diskquota_artifacts \
       -v <PATH_TO_YOUR_DISKQUOTA_SCR_ROOT>:/home/gpadmin/diskquota_src \
       -v <PATH_TO_CMAKE_INSTALL_SCRIPT__REFER_TO_DISKQUOTA_README_FILE>:/home/gpadmin/bin_cmake/cmake-3.20.0-linux-x86_64.sh \
       hub.adsw.io/library/gpdb7_u22:feature_ADBDEV-6552 diskquota_src/concourse/scripts/entry.sh build

docker run --rm -it --sysctl 'kernel.sem=500 1024000 200 4096' \
       -v /tmp/diskquota_artifacts:/home/gpadmin/diskquota_artifacts \
       -v <PATH_TO_YOUR_DISKQUOTA_SCR_ROOT>:/home/gpadmin/diskquota_src \
       -v <PATH_TO_CMAKE_INSTALL_SCRIPT__REFER_TO_DISKQUOTA_README_FILE>:/home/gpadmin/bin_cmake/cmake-3.20.0-linux-x86_64.sh \
       hub.adsw.io/library/gpdb7_u22:feature_ADBDEV-6552 bash
```

In the container:

```
diskquota_src/concourse/scripts/entry.sh test
export PATH=$PATH:/usr/local/greenplum-db-devel/bin/
# note, that after the tests, primary coordinatory is down, and standby is working, so use port 7001
psql postgres -U gpadmin -h localhost -p 7001 -c "show shared_preload_libraries;"
```

Result before the patch:
```
 shared_preload_libraries 
--------------------------
 diskquota-2.3.so
(1 row)
```

Result after the patch:
```
 shared_preload_libraries 
--------------------------
 orca,diskquota-2.3.so
(1 row)

```

