### PR TITLE
ADBDEV-7212: Fix unused variables issues

### DIFF
--- a/src/diskquota.c
+++ b/src/diskquota.c
@@ -834,9 +834,6 @@ disk_quota_launcher_main(Datum main_arg)
 			}
 		}
 
-		bool sigusr1 = false;
-		bool sigusr2 = false;
-
 		/*
 		 * background workers mustn't call usleep() or any direct equivalent:
 		 * instead, they may wait on their process latch, which sleeps as
@@ -864,7 +861,6 @@ disk_quota_launcher_main(Datum main_arg)
 			elog(DEBUG1, "[diskquota] got sigusr2");
 			got_sigusr2 = false;
 			process_extension_ddl_message();
-			sigusr2 = true;
 		}
 
 		/* in case of a SIGHUP, just reload the configuration. */
@@ -884,7 +880,6 @@ disk_quota_launcher_main(Datum main_arg)
 		{
 			elog(DEBUG1, "[diskquota] got sigusr1");
 			got_sigusr1 = false;
-			sigusr1     = true;
 		}
 
 		/*


### PR DESCRIPTION
Fix unused variables issues

Remove unused variables sigusr1 and sigusr2 that prevented compilation with
new flags. These variables were introduced in
082ac9a000f2b3ebd803fb69ea8517432aa2148b. They are meant to track when SIGUSR1
and SIGUSR2 signals occur, but they're never actually read, so it's safe to
remove them.