### PR TITLE
Auto cleaning of configuration tables

### DIFF
--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -22,12 +22,8 @@
 #endif /* GP_VERSION_NUM */
 #include "access/xact.h"
 #include "catalog/catalog.h"
-#include "catalog/namespace.h"
 #include "catalog/objectaccess.h"
-#include "catalog/pg_authid.h"
 #include "catalog/pg_extension.h"
-#include "catalog/pg_namespace.h"
-#include "catalog/pg_tablespace.h"
 #include "cdb/cdbdisp_query.h"
 #include "cdb/cdbdispatchresult.h"
 #include "cdb/cdbvars.h"
@@ -202,78 +198,15 @@ object_access_hook_QuotaStmt(ObjectAccessType access, Oid classId, Oid objectId,
 {
 	if (prev_object_access_hook) (*prev_object_access_hook)(access, classId, objectId, subId, arg);
 
-	if (access == OAT_DROP)
+	/* if is 'drop extension diskquota' */
+	if (classId == ExtensionRelationId && access == OAT_DROP)
 	{
-		switch (classId)
+		if (get_extension_oid("diskquota", true) == objectId)
 		{
-			case ExtensionRelationId:
-				/* if is 'drop extension diskquota' */
-				if (get_extension_oid("diskquota", true) == objectId)
-				{
-					invalidate_database_rejectmap(MyDatabaseId);
-					diskquota_stop_worker();
-				}
-				return;
-
-			case NamespaceRelationId:
-			case AuthIdRelationId:
-			case TableSpaceRelationId: {
-				if (Gp_role != GP_ROLE_DISPATCH) return;
-
-				Oid namespaceId = get_namespace_oid("diskquota", true);
-				if (!OidIsValid(namespaceId) || !OidIsValid(get_relname_relid("quota_config", namespaceId)) ||
-				    !OidIsValid(get_relname_relid("target", namespaceId)))
-					return;
-
-				bool connected_in_this_function = SPI_connect_if_not_yet();
-				if (classId == TableSpaceRelationId)
-				{
-					SPI_execute_with_args("delete from diskquota.target where tablespaceOid = $1", 1,
-					                      (Oid[]){
-					                              OIDOID,
-					                      },
-					                      (Datum[]){
-					                              ObjectIdGetDatum(objectId),
-					                      },
-					                      NULL, false, 0);
-				}
-				else
-				{
-					SPI_execute_with_args(
-					        "delete from diskquota.target where quotaType = $1 and primaryOid = $2", 2,
-					        (Oid[]){
-					                INT4OID,
-					                OIDOID,
-					        },
-					        (Datum[]){
-					                Int32GetDatum(classId == NamespaceRelationId ? NAMESPACE_TABLESPACE_QUOTA
-					                                                             : ROLE_TABLESPACE_QUOTA),
-					                ObjectIdGetDatum(objectId),
-					        },
-					        NULL, false, 0);
-				}
-
-				SPI_execute_with_args(
-				        "delete from diskquota.quota_config where (quotaType = $1 and targetOid = $2)"
-				        " or (quotaType in (2, 3) and (targetOid, quotaType) not in (select rowId, quotaType from "
-				        "diskquota.target))",
-				        2,
-				        (Oid[]){
-				                INT4OID,
-				                OIDOID,
-				        },
-				        (Datum[]){
-				                Int32GetDatum(classId == NamespaceRelationId
-				                                      ? NAMESPACE_QUOTA
-				                                      : (classId == AuthIdRelationId ? ROLE_QUOTA : TABLESPACE_QUOTA)),
-				                ObjectIdGetDatum(objectId),
-				        },
-				        NULL, false, 0);
-
-				SPI_finish_if(connected_in_this_function);
-				return;
-			}
+			invalidate_database_rejectmap(MyDatabaseId);
+			diskquota_stop_worker();
 		}
+		return;
 	}
 
 	/* TODO: do we need to use "&&" instead of "||"? */

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -22,8 +22,12 @@
 #endif /* GP_VERSION_NUM */
 #include "access/xact.h"
 #include "catalog/catalog.h"
+#include "catalog/namespace.h"
 #include "catalog/objectaccess.h"
+#include "catalog/pg_authid.h"
 #include "catalog/pg_extension.h"
+#include "catalog/pg_namespace.h"
+#include "catalog/pg_tablespace.h"
 #include "cdb/cdbdisp_query.h"
 #include "cdb/cdbdispatchresult.h"
 #include "cdb/cdbvars.h"
@@ -198,15 +202,78 @@ object_access_hook_QuotaStmt(ObjectAccessType access, Oid classId, Oid objectId,
 {
 	if (prev_object_access_hook) (*prev_object_access_hook)(access, classId, objectId, subId, arg);
 
-	/* if is 'drop extension diskquota' */
-	if (classId == ExtensionRelationId && access == OAT_DROP)
+	if (access == OAT_DROP)
 	{
-		if (get_extension_oid("diskquota", true) == objectId)
+		switch (classId)
 		{
-			invalidate_database_rejectmap(MyDatabaseId);
-			diskquota_stop_worker();
+			case ExtensionRelationId:
+				/* if is 'drop extension diskquota' */
+				if (get_extension_oid("diskquota", true) == objectId)
+				{
+					invalidate_database_rejectmap(MyDatabaseId);
+					diskquota_stop_worker();
+				}
+				return;
+
+			case NamespaceRelationId:
+			case AuthIdRelationId:
+			case TableSpaceRelationId: {
+				if (Gp_role != GP_ROLE_DISPATCH) return;
+
+				Oid namespaceId = get_namespace_oid("diskquota", true);
+				if (!OidIsValid(namespaceId) || !OidIsValid(get_relname_relid("quota_config", namespaceId)) ||
+				    !OidIsValid(get_relname_relid("target", namespaceId)))
+					return;
+
+				bool connected_in_this_function = SPI_connect_if_not_yet();
+				if (classId == TableSpaceRelationId)
+				{
+					SPI_execute_with_args("delete from diskquota.target where tablespaceOid = $1", 1,
+					                      (Oid[]){
+					                              OIDOID,
+					                      },
+					                      (Datum[]){
+					                              ObjectIdGetDatum(objectId),
+					                      },
+					                      NULL, false, 0);
+				}
+				else
+				{
+					SPI_execute_with_args(
+					        "delete from diskquota.target where quotaType = $1 and primaryOid = $2", 2,
+					        (Oid[]){
+					                INT4OID,
+					                OIDOID,
+					        },
+					        (Datum[]){
+					                Int32GetDatum(classId == NamespaceRelationId ? NAMESPACE_TABLESPACE_QUOTA
+					                                                             : ROLE_TABLESPACE_QUOTA),
+					                ObjectIdGetDatum(objectId),
+					        },
+					        NULL, false, 0);
+				}
+
+				SPI_execute_with_args(
+				        "delete from diskquota.quota_config where (quotaType = $1 and targetOid = $2)"
+				        " or (quotaType in (2, 3) and (targetOid, quotaType) not in (select rowId, quotaType from "
+				        "diskquota.target))",
+				        2,
+				        (Oid[]){
+				                INT4OID,
+				                OIDOID,
+				        },
+				        (Datum[]){
+				                Int32GetDatum(classId == NamespaceRelationId
+				                                      ? NAMESPACE_QUOTA
+				                                      : (classId == AuthIdRelationId ? ROLE_QUOTA : TABLESPACE_QUOTA)),
+				                ObjectIdGetDatum(objectId),
+				        },
+				        NULL, false, 0);
+
+				SPI_finish_if(connected_in_this_function);
+				return;
+			}
 		}
-		return;
 	}
 
 	/* TODO: do we need to use "&&" instead of "||"? */

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -1475,6 +1475,7 @@ do_load_quotas(void)
 		                       get_database_name(MyDatabaseId))));
 	}
 
+	bool cleanConfigTables = false;
 	for (i = 0; i < SPI_processed; i++)
 	{
 		HeapTuple tup = SPI_tuptable->vals[i];
@@ -1503,6 +1504,22 @@ do_load_quotas(void)
 			targetOid = primaryOid;
 		}
 
+		int cacheid = AUTHOID;
+		switch (quotaType)
+		{
+			case NAMESPACE_QUOTA:
+			case NAMESPACE_TABLESPACE_QUOTA:
+				cacheid = NAMESPACEOID;
+				/* fallthrough */
+			case ROLE_QUOTA:
+			case ROLE_TABLESPACE_QUOTA:
+				if (!SearchSysCacheExists1(cacheid, ObjectIdGetDatum(targetOid)))
+				{
+					cleanConfigTables = true;
+					continue;
+				}
+		}
+
 		if (spcOid == InvalidOid)
 		{
 			if (quotaType == NAMESPACE_TABLESPACE_QUOTA || quotaType == ROLE_TABLESPACE_QUOTA)
@@ -1515,8 +1532,29 @@ do_load_quotas(void)
 		}
 		else
 		{
-			update_limit_for_quota(quota_limit_mb * (1 << 20), segratio, quotaType, (Oid[]){targetOid, spcOid});
+			if (SearchSysCacheExists1(TABLESPACEOID, ObjectIdGetDatum(spcOid)))
+				update_limit_for_quota(quota_limit_mb * (1 << 20), segratio, quotaType, (Oid[]){targetOid, spcOid});
+			else
+				cleanConfigTables = true;
 		}
+	}
+
+	if (cleanConfigTables)
+	{
+		SPI_execute(
+		        "delete from diskquota.target"
+		        " where (quotaType = 2 and primaryOid not in (select oid from pg_namespace))"
+		        "    or (quotaType = 3 and primaryOid not in (select oid from pg_roles))"
+		        "    or tablespaceOid not in (select oid from pg_tablespace)",
+		        false, 0);
+		SPI_execute(
+		        "delete from diskquota.quota_config"
+		        " where (quotaType = 0 and targetOid not in (select oid from pg_namespace))"
+		        "    or (quotaType = 1 and targetOid not in (select oid from pg_roles))"
+		        "    or (quotaType = 4 and targetOid not in (select oid from pg_tablespace))"
+		        "    or (quotaType in (2, 3) and (targetOid, quotaType) not in (select rowId, quotaType from "
+		        "diskquota.target))",
+		        false, 0);
 	}
 
 	SPI_finish_if(connected_in_this_function);

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -1551,8 +1551,8 @@ do_load_quotas(void)
 		        " where (quotaType = $1 and targetOid not in (select oid from pg_namespace))"
 		        "    or (quotaType = $2 and targetOid not in (select oid from pg_roles))"
 		        "    or (quotaType = $3 and targetOid not in (select oid from pg_tablespace))"
-		        "    or (quotaType in ($4, $5) and (targetOid, quotaType) not in (select rowId, quotaType from "
-		        "diskquota.target))",
+		        "    or (quotaType in ($4, $5)"
+		        "        and (targetOid, quotaType) not in (select rowId, quotaType from diskquota.target))",
 		        5,
 		        (Oid[]){
 		                INT4OID,

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -1504,25 +1504,7 @@ do_load_quotas(void)
 			targetOid = primaryOid;
 		}
 
-		int cacheid;
-		switch (quotaType)
-		{
-			case NAMESPACE_QUOTA:
-			case NAMESPACE_TABLESPACE_QUOTA:
-				cacheid = NAMESPACEOID;
-				break;
-			case ROLE_QUOTA:
-			case ROLE_TABLESPACE_QUOTA:
-				cacheid = AUTHOID;
-				break;
-			case TABLESPACE_QUOTA:
-				cacheid = TABLESPACEOID;
-				break;
-			default:
-				Assert(false); /* never reach here */
-		}
-
-		if (!SearchSysCacheExists1(cacheid, ObjectIdGetDatum(targetOid)))
+		if (!SearchSysCacheExists1(quota_key_caches[quotaType][0], ObjectIdGetDatum(targetOid)))
 		{
 			cleanConfigTables = true;
 			continue;
@@ -1549,20 +1531,44 @@ do_load_quotas(void)
 
 	if (cleanConfigTables)
 	{
-		SPI_execute(
+		SPI_execute_with_args(
 		        "delete from diskquota.target"
-		        " where (quotaType = 2 and primaryOid not in (select oid from pg_namespace))"
-		        "    or (quotaType = 3 and primaryOid not in (select oid from pg_roles))"
+		        " where (quotaType = $1 and primaryOid not in (select oid from pg_namespace))"
+		        "    or (quotaType = $2 and primaryOid not in (select oid from pg_roles))"
 		        "    or tablespaceOid not in (select oid from pg_tablespace)",
-		        false, 0);
-		SPI_execute(
+		        2,
+		        (Oid[]){
+		                INT4OID,
+		                INT4OID,
+		        },
+		        (Datum[]){
+		                Int32GetDatum(NAMESPACE_TABLESPACE_QUOTA),
+		                Int32GetDatum(ROLE_TABLESPACE_QUOTA),
+		        },
+		        NULL, false, 0);
+		SPI_execute_with_args(
 		        "delete from diskquota.quota_config"
-		        " where (quotaType = 0 and targetOid not in (select oid from pg_namespace))"
-		        "    or (quotaType = 1 and targetOid not in (select oid from pg_roles))"
-		        "    or (quotaType = 4 and targetOid not in (select oid from pg_tablespace))"
-		        "    or (quotaType in (2, 3) and (targetOid, quotaType) not in (select rowId, quotaType from "
+		        " where (quotaType = $1 and targetOid not in (select oid from pg_namespace))"
+		        "    or (quotaType = $2 and targetOid not in (select oid from pg_roles))"
+		        "    or (quotaType = $3 and targetOid not in (select oid from pg_tablespace))"
+		        "    or (quotaType in ($4, $5) and (targetOid, quotaType) not in (select rowId, quotaType from "
 		        "diskquota.target))",
-		        false, 0);
+		        5,
+		        (Oid[]){
+		                INT4OID,
+		                INT4OID,
+		                INT4OID,
+		                INT4OID,
+		                INT4OID,
+		        },
+		        (Datum[]){
+		                Int32GetDatum(NAMESPACE_QUOTA),
+		                Int32GetDatum(ROLE_QUOTA),
+		                Int32GetDatum(TABLESPACE_QUOTA),
+		                Int32GetDatum(NAMESPACE_TABLESPACE_QUOTA),
+		                Int32GetDatum(ROLE_TABLESPACE_QUOTA),
+		        },
+		        NULL, false, 0);
 	}
 
 	SPI_finish_if(connected_in_this_function);

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -1504,20 +1504,28 @@ do_load_quotas(void)
 			targetOid = primaryOid;
 		}
 
-		int cacheid = AUTHOID;
+		int cacheid;
 		switch (quotaType)
 		{
 			case NAMESPACE_QUOTA:
 			case NAMESPACE_TABLESPACE_QUOTA:
 				cacheid = NAMESPACEOID;
-				/* fallthrough */
+				break;
 			case ROLE_QUOTA:
 			case ROLE_TABLESPACE_QUOTA:
-				if (!SearchSysCacheExists1(cacheid, ObjectIdGetDatum(targetOid)))
-				{
-					cleanConfigTables = true;
-					continue;
-				}
+				cacheid = AUTHOID;
+				break;
+			case TABLESPACE_QUOTA:
+				cacheid = TABLESPACEOID;
+				break;
+			default:
+				Assert(false); /* never reach here */
+		}
+
+		if (!SearchSysCacheExists1(cacheid, ObjectIdGetDatum(targetOid)))
+		{
+			cleanConfigTables = true;
+			continue;
 		}
 
 		if (spcOid == InvalidOid)

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -1499,6 +1499,13 @@ do_load_quotas(void)
 		Oid   spcOid         = DatumGetObjectId(vals[4]);
 		Oid   primaryOid     = DatumGetObjectId(vals[5]);
 
+		if (quotaType < 0 || quotaType >= NUM_QUOTA_TYPES)
+		{
+			ereport(ERROR,
+			        (errcode(ERRCODE_INTERNAL_ERROR),
+			         errmsg("[diskquota] diskquota.quota_config.quotaType MUST be >= 0 and < %d", NUM_QUOTA_TYPES)));
+		}
+
 		if (quotaType == NAMESPACE_TABLESPACE_QUOTA || quotaType == ROLE_TABLESPACE_QUOTA)
 		{
 			targetOid = primaryOid;

--- a/tests/regress/diskquota_schedule
+++ b/tests/regress/diskquota_schedule
@@ -44,5 +44,6 @@ test: test_tablespace_diff_schema
 # test: test_worker_schedule_exception
 test: test_dbname_encoding
 test: test_drop_any_extension
+test: test_clean_config_tables
 test: test_drop_extension
 test: reset_config

--- a/tests/regress/expected/test_clean_config_tables.out
+++ b/tests/regress/expected/test_clean_config_tables.out
@@ -1,0 +1,204 @@
+-- Test auto cleaning of configuration tables (diskquota.quota_config and
+-- diskquota.target) when schema, tablespace or role is dropped.
+\! rm -rf /tmp/ts{1,2,3}
+TRUNCATE TABLE diskquota.target;
+TRUNCATE TABLE diskquota.quota_config;
+-- NAMESPACE_QUOTA
+CREATE SCHEMA s1;
+CREATE SCHEMA s2;
+CREATE SCHEMA s3;
+SELECT diskquota.set_schema_quota(s, '1GB')
+FROM (VALUES('s1'), ('s2'), ('s3')) v(s);
+ set_schema_quota 
+------------------
+ 
+ 
+ 
+(3 rows)
+
+DROP SCHEMA s2;
+SELECT n.nspname
+FROM diskquota.quota_config c
+LEFT JOIN pg_namespace n ON n.oid = c.targetoid
+WHERE c.quotatype = 0;
+ nspname 
+---------
+ s1
+ s3
+(2 rows)
+
+-- ROLE_QUOTA
+CREATE ROLE r1;
+NOTICE:  resource queue required -- using default resource queue "pg_default"
+CREATE ROLE r2;
+NOTICE:  resource queue required -- using default resource queue "pg_default"
+CREATE ROLE r3;
+NOTICE:  resource queue required -- using default resource queue "pg_default"
+SELECT diskquota.set_role_quota(r, '100GB')
+FROM (VALUES('r1'), ('r2'), ('r3')) v(r);
+ set_role_quota 
+----------------
+ 
+ 
+ 
+(3 rows)
+
+DROP ROLE r2;
+SELECT a.rolname
+FROM diskquota.quota_config c
+LEFT JOIN pg_authid a ON a.oid = c.targetoid
+WHERE c.quotatype = 1;
+ rolname 
+---------
+ r3
+ r1
+(2 rows)
+
+-- TABLESPACE_QUOTA
+\! mkdir -p /tmp/ts{1,2,3}
+CREATE TABLESPACE ts1 LOCATION '/tmp/ts1';
+CREATE TABLESPACE ts2 LOCATION '/tmp/ts2';
+CREATE TABLESPACE ts3 LOCATION '/tmp/ts3';
+SELECT diskquota.set_per_segment_quota(ts, '10.0')
+FROM (VALUES('ts1'), ('ts2'), ('ts3')) v(ts);
+ set_per_segment_quota 
+-----------------------
+ 
+ 
+ 
+(3 rows)
+
+DROP TABLESPACE ts2;
+SELECT s.spcname
+FROM diskquota.quota_config c
+LEFT JOIN pg_tablespace s ON s.oid = c.targetoid
+WHERE c.quotatype = 4;
+ spcname 
+---------
+ ts1
+ ts3
+(2 rows)
+
+-- NAMESPACE_TABLESPACE_QUOTA
+SELECT diskquota.set_schema_tablespace_quota(s, ts, '1GB')
+FROM (VALUES ('s1'), ('s3')) AS vs(s), (VALUES ('ts1'), ('ts3')) AS vts(ts);
+ set_schema_tablespace_quota 
+-----------------------------
+ 
+ 
+ 
+ 
+(4 rows)
+
+DROP SCHEMA s1;
+SELECT count() FROM diskquota.quota_config WHERE quotatype = 2;
+ count 
+-------
+     2
+(1 row)
+
+SELECT s.spcname, n.nspname
+FROM diskquota.target c
+LEFT JOIN pg_tablespace s ON s.oid = c.tablespaceoid
+LEFT JOIN pg_namespace n ON n.oid = c.primaryoid
+WHERE c.quotatype = 2;
+ spcname | nspname 
+---------+---------
+ ts1     | s3
+ ts3     | s3
+(2 rows)
+
+DROP TABLESPACE ts3;
+SELECT count() FROM diskquota.quota_config WHERE quotatype = 2;
+ count 
+-------
+     1
+(1 row)
+
+SELECT s.spcname, n.nspname
+FROM diskquota.target c
+LEFT JOIN pg_tablespace s ON s.oid = c.tablespaceoid
+LEFT JOIN pg_namespace n ON n.oid = c.primaryoid
+WHERE c.quotatype = 2;
+ spcname | nspname 
+---------+---------
+ ts1     | s3
+(1 row)
+
+-- ROLE_TABLESPACE_QUOTA
+CREATE TABLESPACE ts3 LOCATION '/tmp/ts3';
+SELECT diskquota.set_role_tablespace_quota(r, ts, '1GB')
+FROM (VALUES ('r1'), ('r3')) AS vr(r), (VALUES ('ts1'), ('ts3')) AS vts(ts);
+ set_role_tablespace_quota 
+---------------------------
+ 
+ 
+ 
+ 
+(4 rows)
+
+DROP ROLE r1;
+SELECT count() FROM diskquota.quota_config WHERE quotatype = 3;
+ count 
+-------
+     2
+(1 row)
+
+SELECT s.spcname, a.rolname
+FROM diskquota.target c
+LEFT JOIN pg_tablespace s ON s.oid = c.tablespaceoid
+LEFT JOIN pg_authid a ON a.oid = c.primaryoid
+WHERE c.quotatype = 3;
+ spcname | rolname 
+---------+---------
+ ts3     | r3
+ ts1     | r3
+(2 rows)
+
+DROP TABLESPACE ts3;
+SELECT count() FROM diskquota.quota_config WHERE quotatype = 3;
+ count 
+-------
+     1
+(1 row)
+
+SELECT s.spcname, a.rolname
+FROM diskquota.target c
+LEFT JOIN pg_tablespace s ON s.oid = c.tablespaceoid
+LEFT JOIN pg_authid a ON a.oid = c.primaryoid
+WHERE c.quotatype = 3;
+ spcname | rolname 
+---------+---------
+ ts1     | r3
+(1 row)
+
+-- Test invalid entries cleaning
+TRUNCATE TABLE diskquota.target;
+TRUNCATE TABLE diskquota.quota_config;
+INSERT INTO diskquota.target VALUES (0, 0, 0, 0);
+INSERT INTO diskquota.quota_config VALUES (0, 0, 0, 0);
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t
+(1 row)
+
+SELECT count() FROM diskquota.target;
+ count 
+-------
+     0
+(1 row)
+
+SELECT count() FROM diskquota.quota_config;
+ count 
+-------
+     0
+(1 row)
+
+-- cleanup
+TRUNCATE TABLE diskquota.target;
+TRUNCATE TABLE diskquota.quota_config;
+DROP SCHEMA s3;
+DROP ROLE r3;
+DROP TABLESPACE ts1;
+\! rm -rf /tmp/ts{1,2,3}

--- a/tests/regress/expected/test_clean_config_tables.out
+++ b/tests/regress/expected/test_clean_config_tables.out
@@ -1,6 +1,6 @@
 -- Test auto cleaning of configuration tables (diskquota.quota_config and
 -- diskquota.target) when schema, tablespace or role is dropped.
-\! rm -rf /tmp/ts{1,2,3}
+\! rm -rf /tmp/ts1 /tmp/ts2 /tmp/ts3
 TRUNCATE TABLE diskquota.target;
 TRUNCATE TABLE diskquota.quota_config;
 -- NAMESPACE_QUOTA
@@ -55,7 +55,9 @@ WHERE c.quotatype = 1;
 (2 rows)
 
 -- TABLESPACE_QUOTA
-\! mkdir -p /tmp/ts{1,2,3}
+\! mkdir -p /tmp/ts1
+\! mkdir -p /tmp/ts2
+\! mkdir -p /tmp/ts3
 CREATE TABLESPACE ts1 LOCATION '/tmp/ts1';
 CREATE TABLESPACE ts2 LOCATION '/tmp/ts2';
 CREATE TABLESPACE ts3 LOCATION '/tmp/ts3';
@@ -201,4 +203,4 @@ TRUNCATE TABLE diskquota.quota_config;
 DROP SCHEMA s3;
 DROP ROLE r3;
 DROP TABLESPACE ts1;
-\! rm -rf /tmp/ts{1,2,3}
+\! rm -rf /tmp/ts1 /tmp/ts2 /tmp/ts3

--- a/tests/regress/expected/test_clean_config_tables.out
+++ b/tests/regress/expected/test_clean_config_tables.out
@@ -1,5 +1,21 @@
 -- Test auto cleaning of configuration tables (diskquota.quota_config and
 -- diskquota.target) when schema, tablespace or role is dropped.
+-- start_ignore
+DROP SCHEMA IF EXISTS s1, s2, s3 CASCADE;
+NOTICE:  schema "s1" does not exist, skipping
+NOTICE:  schema "s2" does not exist, skipping
+NOTICE:  schema "s3" does not exist, skipping
+DROP ROLE IF EXISTS r1, r2, r3;
+NOTICE:  role "r1" does not exist, skipping
+NOTICE:  role "r2" does not exist, skipping
+NOTICE:  role "r3" does not exist, skipping
+DROP TABLESPACE IF EXISTS ts1;
+NOTICE:  tablespace "ts1" does not exist, skipping
+DROP TABLESPACE IF EXISTS ts2;
+NOTICE:  tablespace "ts2" does not exist, skipping
+DROP TABLESPACE IF EXISTS ts3;
+NOTICE:  tablespace "ts3" does not exist, skipping
+-- end_ignore
 \! rm -rf /tmp/ts1 /tmp/ts2 /tmp/ts3
 TRUNCATE TABLE diskquota.target;
 TRUNCATE TABLE diskquota.quota_config;
@@ -17,6 +33,12 @@ FROM (VALUES('s1'), ('s2'), ('s3')) v(s);
 (3 rows)
 
 DROP SCHEMA s2;
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t
+(1 row)
+
 SELECT n.nspname
 FROM diskquota.quota_config c
 LEFT JOIN pg_namespace n ON n.oid = c.targetoid
@@ -44,14 +66,20 @@ FROM (VALUES('r1'), ('r2'), ('r3')) v(r);
 (3 rows)
 
 DROP ROLE r2;
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t
+(1 row)
+
 SELECT a.rolname
 FROM diskquota.quota_config c
 LEFT JOIN pg_authid a ON a.oid = c.targetoid
 WHERE c.quotatype = 1;
  rolname 
 ---------
- r3
  r1
+ r3
 (2 rows)
 
 -- TABLESPACE_QUOTA
@@ -71,6 +99,12 @@ FROM (VALUES('ts1'), ('ts2'), ('ts3')) v(ts);
 (3 rows)
 
 DROP TABLESPACE ts2;
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t
+(1 row)
+
 SELECT s.spcname
 FROM diskquota.quota_config c
 LEFT JOIN pg_tablespace s ON s.oid = c.targetoid
@@ -93,6 +127,12 @@ FROM (VALUES ('s1'), ('s3')) AS vs(s), (VALUES ('ts1'), ('ts3')) AS vts(ts);
 (4 rows)
 
 DROP SCHEMA s1;
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t
+(1 row)
+
 SELECT count() FROM diskquota.quota_config WHERE quotatype = 2;
  count 
 -------
@@ -106,11 +146,17 @@ LEFT JOIN pg_namespace n ON n.oid = c.primaryoid
 WHERE c.quotatype = 2;
  spcname | nspname 
 ---------+---------
- ts1     | s3
  ts3     | s3
+ ts1     | s3
 (2 rows)
 
 DROP TABLESPACE ts3;
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t
+(1 row)
+
 SELECT count() FROM diskquota.quota_config WHERE quotatype = 2;
  count 
 -------
@@ -140,6 +186,12 @@ FROM (VALUES ('r1'), ('r3')) AS vr(r), (VALUES ('ts1'), ('ts3')) AS vts(ts);
 (4 rows)
 
 DROP ROLE r1;
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t
+(1 row)
+
 SELECT count() FROM diskquota.quota_config WHERE quotatype = 3;
  count 
 -------
@@ -153,11 +205,17 @@ LEFT JOIN pg_authid a ON a.oid = c.primaryoid
 WHERE c.quotatype = 3;
  spcname | rolname 
 ---------+---------
- ts3     | r3
  ts1     | r3
+ ts3     | r3
 (2 rows)
 
 DROP TABLESPACE ts3;
+SELECT diskquota.wait_for_worker_new_epoch();
+ wait_for_worker_new_epoch 
+---------------------------
+ t
+(1 row)
+
 SELECT count() FROM diskquota.quota_config WHERE quotatype = 3;
  count 
 -------

--- a/tests/regress/expected/test_clean_config_tables.out
+++ b/tests/regress/expected/test_clean_config_tables.out
@@ -146,11 +146,11 @@ LEFT JOIN pg_namespace n ON n.oid = c.primaryoid
 WHERE c.quotatype = 2;
  spcname | nspname 
 ---------+---------
- ts3     | s3
  ts1     | s3
+ ts3     | s3
 (2 rows)
 
-DROP TABLESPACE ts3;
+DROP TABLESPACE ts1;
 SELECT diskquota.wait_for_worker_new_epoch();
  wait_for_worker_new_epoch 
 ---------------------------
@@ -170,11 +170,11 @@ LEFT JOIN pg_namespace n ON n.oid = c.primaryoid
 WHERE c.quotatype = 2;
  spcname | nspname 
 ---------+---------
- ts1     | s3
+ ts3     | s3
 (1 row)
 
 -- ROLE_TABLESPACE_QUOTA
-CREATE TABLESPACE ts3 LOCATION '/tmp/ts3';
+CREATE TABLESPACE ts1 LOCATION '/tmp/ts1';
 SELECT diskquota.set_role_tablespace_quota(r, ts, '1GB')
 FROM (VALUES ('r1'), ('r3')) AS vr(r), (VALUES ('ts1'), ('ts3')) AS vts(ts);
  set_role_tablespace_quota 
@@ -209,7 +209,7 @@ WHERE c.quotatype = 3;
  ts3     | r3
 (2 rows)
 
-DROP TABLESPACE ts3;
+DROP TABLESPACE ts1;
 SELECT diskquota.wait_for_worker_new_epoch();
  wait_for_worker_new_epoch 
 ---------------------------
@@ -229,7 +229,7 @@ LEFT JOIN pg_authid a ON a.oid = c.primaryoid
 WHERE c.quotatype = 3;
  spcname | rolname 
 ---------+---------
- ts1     | r3
+ ts3     | r3
 (1 row)
 
 -- Test invalid entries cleaning
@@ -260,5 +260,5 @@ TRUNCATE TABLE diskquota.target;
 TRUNCATE TABLE diskquota.quota_config;
 DROP SCHEMA s3;
 DROP ROLE r3;
-DROP TABLESPACE ts1;
+DROP TABLESPACE ts3;
 \! rm -rf /tmp/ts1 /tmp/ts2 /tmp/ts3

--- a/tests/regress/sql/test_clean_config_tables.sql
+++ b/tests/regress/sql/test_clean_config_tables.sql
@@ -1,0 +1,143 @@
+-- Test auto cleaning of configuration tables (diskquota.quota_config and
+-- diskquota.target) when schema, tablespace or role is dropped.
+
+-- start_ignore
+DROP SCHEMA IF EXISTS s1, s2, s3;
+DROP ROLE IF EXISTS r1, r2, r3;
+DROP TABLESPACE IF EXISTS ts1;
+DROP TABLESPACE IF EXISTS ts2;
+DROP TABLESPACE IF EXISTS ts3;
+-- end_ignore
+\! rm -rf /tmp/ts{1,2,3}
+TRUNCATE TABLE diskquota.target;
+TRUNCATE TABLE diskquota.quota_config;
+
+
+-- NAMESPACE_QUOTA
+
+CREATE SCHEMA s1;
+CREATE SCHEMA s2;
+CREATE SCHEMA s3;
+
+SELECT diskquota.set_schema_quota(s, '1GB')
+FROM (VALUES('s1'), ('s2'), ('s3')) v(s);
+
+DROP SCHEMA s2;
+
+SELECT n.nspname
+FROM diskquota.quota_config c
+LEFT JOIN pg_namespace n ON n.oid = c.targetoid
+WHERE c.quotatype = 0;
+
+
+-- ROLE_QUOTA
+
+CREATE ROLE r1;
+CREATE ROLE r2;
+CREATE ROLE r3;
+
+SELECT diskquota.set_role_quota(r, '100GB')
+FROM (VALUES('r1'), ('r2'), ('r3')) v(r);
+
+DROP ROLE r2;
+
+SELECT a.rolname
+FROM diskquota.quota_config c
+LEFT JOIN pg_authid a ON a.oid = c.targetoid
+WHERE c.quotatype = 1;
+
+
+-- TABLESPACE_QUOTA
+
+\! mkdir -p /tmp/ts{1,2,3}
+CREATE TABLESPACE ts1 LOCATION '/tmp/ts1';
+CREATE TABLESPACE ts2 LOCATION '/tmp/ts2';
+CREATE TABLESPACE ts3 LOCATION '/tmp/ts3';
+
+SELECT diskquota.set_per_segment_quota(ts, '10.0')
+FROM (VALUES('ts1'), ('ts2'), ('ts3')) v(ts);
+
+DROP TABLESPACE ts2;
+
+SELECT s.spcname
+FROM diskquota.quota_config c
+LEFT JOIN pg_tablespace s ON s.oid = c.targetoid
+WHERE c.quotatype = 4;
+
+
+-- NAMESPACE_TABLESPACE_QUOTA
+
+SELECT diskquota.set_schema_tablespace_quota(s, ts, '1GB')
+FROM (VALUES ('s1'), ('s3')) AS vs(s), (VALUES ('ts1'), ('ts3')) AS vts(ts);
+
+DROP SCHEMA s1;
+
+SELECT count() FROM diskquota.quota_config WHERE quotatype = 2;
+
+SELECT s.spcname, n.nspname
+FROM diskquota.target c
+LEFT JOIN pg_tablespace s ON s.oid = c.tablespaceoid
+LEFT JOIN pg_namespace n ON n.oid = c.primaryoid
+WHERE c.quotatype = 2;
+
+DROP TABLESPACE ts3;
+
+SELECT count() FROM diskquota.quota_config WHERE quotatype = 2;
+
+SELECT s.spcname, n.nspname
+FROM diskquota.target c
+LEFT JOIN pg_tablespace s ON s.oid = c.tablespaceoid
+LEFT JOIN pg_namespace n ON n.oid = c.primaryoid
+WHERE c.quotatype = 2;
+
+
+-- ROLE_TABLESPACE_QUOTA
+
+CREATE TABLESPACE ts3 LOCATION '/tmp/ts3';
+
+SELECT diskquota.set_role_tablespace_quota(r, ts, '1GB')
+FROM (VALUES ('r1'), ('r3')) AS vr(r), (VALUES ('ts1'), ('ts3')) AS vts(ts);
+
+DROP ROLE r1;
+
+SELECT count() FROM diskquota.quota_config WHERE quotatype = 3;
+
+SELECT s.spcname, a.rolname
+FROM diskquota.target c
+LEFT JOIN pg_tablespace s ON s.oid = c.tablespaceoid
+LEFT JOIN pg_authid a ON a.oid = c.primaryoid
+WHERE c.quotatype = 3;
+
+DROP TABLESPACE ts3;
+
+SELECT count() FROM diskquota.quota_config WHERE quotatype = 3;
+
+SELECT s.spcname, a.rolname
+FROM diskquota.target c
+LEFT JOIN pg_tablespace s ON s.oid = c.tablespaceoid
+LEFT JOIN pg_authid a ON a.oid = c.primaryoid
+WHERE c.quotatype = 3;
+
+
+-- Test invalid entries cleaning
+
+TRUNCATE TABLE diskquota.target;
+TRUNCATE TABLE diskquota.quota_config;
+
+INSERT INTO diskquota.target VALUES (0, 0, 0, 0);
+INSERT INTO diskquota.quota_config VALUES (0, 0, 0, 0);
+
+SELECT diskquota.wait_for_worker_new_epoch();
+
+SELECT count() FROM diskquota.target;
+SELECT count() FROM diskquota.quota_config;
+
+
+-- cleanup
+
+TRUNCATE TABLE diskquota.target;
+TRUNCATE TABLE diskquota.quota_config;
+DROP SCHEMA s3;
+DROP ROLE r3;
+DROP TABLESPACE ts1;
+\! rm -rf /tmp/ts{1,2,3}

--- a/tests/regress/sql/test_clean_config_tables.sql
+++ b/tests/regress/sql/test_clean_config_tables.sql
@@ -90,7 +90,7 @@ LEFT JOIN pg_tablespace s ON s.oid = c.tablespaceoid
 LEFT JOIN pg_namespace n ON n.oid = c.primaryoid
 WHERE c.quotatype = 2;
 
-DROP TABLESPACE ts3;
+DROP TABLESPACE ts1;
 
 SELECT diskquota.wait_for_worker_new_epoch();
 
@@ -105,7 +105,7 @@ WHERE c.quotatype = 2;
 
 -- ROLE_TABLESPACE_QUOTA
 
-CREATE TABLESPACE ts3 LOCATION '/tmp/ts3';
+CREATE TABLESPACE ts1 LOCATION '/tmp/ts1';
 
 SELECT diskquota.set_role_tablespace_quota(r, ts, '1GB')
 FROM (VALUES ('r1'), ('r3')) AS vr(r), (VALUES ('ts1'), ('ts3')) AS vts(ts);
@@ -122,7 +122,7 @@ LEFT JOIN pg_tablespace s ON s.oid = c.tablespaceoid
 LEFT JOIN pg_authid a ON a.oid = c.primaryoid
 WHERE c.quotatype = 3;
 
-DROP TABLESPACE ts3;
+DROP TABLESPACE ts1;
 
 SELECT diskquota.wait_for_worker_new_epoch();
 
@@ -155,5 +155,5 @@ TRUNCATE TABLE diskquota.target;
 TRUNCATE TABLE diskquota.quota_config;
 DROP SCHEMA s3;
 DROP ROLE r3;
-DROP TABLESPACE ts1;
+DROP TABLESPACE ts3;
 \! rm -rf /tmp/ts1 /tmp/ts2 /tmp/ts3

--- a/tests/regress/sql/test_clean_config_tables.sql
+++ b/tests/regress/sql/test_clean_config_tables.sql
@@ -2,7 +2,7 @@
 -- diskquota.target) when schema, tablespace or role is dropped.
 
 -- start_ignore
-DROP SCHEMA IF EXISTS s1, s2, s3;
+DROP SCHEMA IF EXISTS s1, s2, s3 CASCADE;
 DROP ROLE IF EXISTS r1, r2, r3;
 DROP TABLESPACE IF EXISTS ts1;
 DROP TABLESPACE IF EXISTS ts2;
@@ -24,6 +24,8 @@ FROM (VALUES('s1'), ('s2'), ('s3')) v(s);
 
 DROP SCHEMA s2;
 
+SELECT diskquota.wait_for_worker_new_epoch();
+
 SELECT n.nspname
 FROM diskquota.quota_config c
 LEFT JOIN pg_namespace n ON n.oid = c.targetoid
@@ -40,6 +42,8 @@ SELECT diskquota.set_role_quota(r, '100GB')
 FROM (VALUES('r1'), ('r2'), ('r3')) v(r);
 
 DROP ROLE r2;
+
+SELECT diskquota.wait_for_worker_new_epoch();
 
 SELECT a.rolname
 FROM diskquota.quota_config c
@@ -61,6 +65,8 @@ FROM (VALUES('ts1'), ('ts2'), ('ts3')) v(ts);
 
 DROP TABLESPACE ts2;
 
+SELECT diskquota.wait_for_worker_new_epoch();
+
 SELECT s.spcname
 FROM diskquota.quota_config c
 LEFT JOIN pg_tablespace s ON s.oid = c.targetoid
@@ -74,6 +80,8 @@ FROM (VALUES ('s1'), ('s3')) AS vs(s), (VALUES ('ts1'), ('ts3')) AS vts(ts);
 
 DROP SCHEMA s1;
 
+SELECT diskquota.wait_for_worker_new_epoch();
+
 SELECT count() FROM diskquota.quota_config WHERE quotatype = 2;
 
 SELECT s.spcname, n.nspname
@@ -83,6 +91,8 @@ LEFT JOIN pg_namespace n ON n.oid = c.primaryoid
 WHERE c.quotatype = 2;
 
 DROP TABLESPACE ts3;
+
+SELECT diskquota.wait_for_worker_new_epoch();
 
 SELECT count() FROM diskquota.quota_config WHERE quotatype = 2;
 
@@ -102,6 +112,8 @@ FROM (VALUES ('r1'), ('r3')) AS vr(r), (VALUES ('ts1'), ('ts3')) AS vts(ts);
 
 DROP ROLE r1;
 
+SELECT diskquota.wait_for_worker_new_epoch();
+
 SELECT count() FROM diskquota.quota_config WHERE quotatype = 3;
 
 SELECT s.spcname, a.rolname
@@ -111,6 +123,8 @@ LEFT JOIN pg_authid a ON a.oid = c.primaryoid
 WHERE c.quotatype = 3;
 
 DROP TABLESPACE ts3;
+
+SELECT diskquota.wait_for_worker_new_epoch();
 
 SELECT count() FROM diskquota.quota_config WHERE quotatype = 3;
 

--- a/tests/regress/sql/test_clean_config_tables.sql
+++ b/tests/regress/sql/test_clean_config_tables.sql
@@ -8,7 +8,7 @@ DROP TABLESPACE IF EXISTS ts1;
 DROP TABLESPACE IF EXISTS ts2;
 DROP TABLESPACE IF EXISTS ts3;
 -- end_ignore
-\! rm -rf /tmp/ts{1,2,3}
+\! rm -rf /tmp/ts1 /tmp/ts2 /tmp/ts3
 TRUNCATE TABLE diskquota.target;
 TRUNCATE TABLE diskquota.quota_config;
 
@@ -49,7 +49,9 @@ WHERE c.quotatype = 1;
 
 -- TABLESPACE_QUOTA
 
-\! mkdir -p /tmp/ts{1,2,3}
+\! mkdir -p /tmp/ts1
+\! mkdir -p /tmp/ts2
+\! mkdir -p /tmp/ts3
 CREATE TABLESPACE ts1 LOCATION '/tmp/ts1';
 CREATE TABLESPACE ts2 LOCATION '/tmp/ts2';
 CREATE TABLESPACE ts3 LOCATION '/tmp/ts3';
@@ -140,4 +142,4 @@ TRUNCATE TABLE diskquota.quota_config;
 DROP SCHEMA s3;
 DROP ROLE r3;
 DROP TABLESPACE ts1;
-\! rm -rf /tmp/ts{1,2,3}
+\! rm -rf /tmp/ts1 /tmp/ts2 /tmp/ts3


### PR DESCRIPTION
Auto cleaning of configuration tables

When dropping schema, role or tablespace, the corresponding entries from
diskquota.quota_config and diskquota.target were not deleted. The fact that they
remain may lead to an unexpected quota on a new scheme, role or tablespace with
the same oid (in the case of oid wraparound).

Add cleaning of configuration tables when invalid record is detected during data
loading from these tables. 

Cleaning at the loading time only is not enough, because scheme, role or
tablespace can be dropped and object of the same type with the same oid can be
created in the period between two loadings. It is possible to use
object_access_hook to handle dropping, but it is difficult, this case is very
unlikely and unexpected quota is not critical problem, because it can be removed
by DBA. So the patch doesn't handle this case.

Ticket: ADBDEV-7208