### PR TITLE
ADBDEV-8915: Add locks when using shared hashmaps

### DIFF
--- a/src/diskquota.h
+++ b/src/diskquota.h
@@ -141,6 +141,9 @@ struct DiskQuotaLocks
 	LWLock *dblist_lock;
 	LWLock *workerlist_lock;
 	LWLock *altered_reloid_cache_lock;
+	LWLock *quota_info_map_lock;
+	LWLock *table_size_map_lock;
+	LWLock *local_disk_quota_reject_map_lock;
 };
 typedef struct DiskQuotaLocks DiskQuotaLocks;
 #define DiskQuotaLocksItemNumber (sizeof(DiskQuotaLocks) / sizeof(void *))
@@ -317,7 +320,7 @@ extern HTAB        *diskquota_hash_create(const char *tabname, long nelem, HASHC
 extern HTAB *DiskquotaShmemInitHash(const char *name, long init_size, long max_size, HASHCTL *infoP, int hash_flags,
                                     DiskquotaHashFunction hash_function);
 extern void  refresh_monitored_dbid_cache(void);
-extern HASHACTION check_hash_fullness(HTAB *hashp, int max_size, const char *warning_message,
+extern HASHACTION check_hash_fullness(LWLock *lock, HTAB *hashp, int max_size, const char *warning_message,
                                       TimestampTz *last_overflow_report);
 bool              SPI_push_cond_and_connect(void);
 void              SPI_finish_and_pop_cond(bool pushed);

--- a/src/diskquota_utility.c
+++ b/src/diskquota_utility.c
@@ -1660,8 +1660,11 @@ DiskquotaShmemInitHash(const char           *name,       /* table string name fo
  * It can be used only under lock.
  */
 HASHACTION
-check_hash_fullness(HTAB *hashp, int max_size, const char *warning_message, TimestampTz *last_overflow_report)
+check_hash_fullness(LWLock *lock, HTAB *hashp, int max_size, const char *warning_message,
+                    TimestampTz *last_overflow_report)
 {
+	Assert(LWLockHeldExclusiveByMe(lock));
+
 	long num_entries = hash_get_num_entries(hashp);
 
 	if (num_entries < max_size) return HASH_ENTER;

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -244,8 +244,9 @@ report_altered_reloid(Oid reloid)
 	if (IsRoleMirror() || IS_QUERY_DISPATCHER()) return;
 
 	LWLockAcquire(diskquota_locks.altered_reloid_cache_lock, LW_EXCLUSIVE);
-	HASHACTION action = check_hash_fullness(altered_reloid_cache, diskquota_max_active_tables,
-	                                        altered_reloid_cache_warning, &altered_reloid_cache_last_overflow_report);
+	HASHACTION action = check_hash_fullness(diskquota_locks.altered_reloid_cache_lock, altered_reloid_cache,
+	                                        diskquota_max_active_tables, altered_reloid_cache_warning,
+	                                        &altered_reloid_cache_last_overflow_report);
 	hash_search(altered_reloid_cache, &reloid, action, NULL);
 	LWLockRelease(diskquota_locks.altered_reloid_cache_lock);
 }
@@ -328,9 +329,10 @@ report_active_table_helper(const RelFileNodeBackend *relFileNode)
 	item.tablespaceoid = relFileNode->node.spcNode;
 
 	LWLockAcquire(diskquota_locks.active_table_lock, LW_EXCLUSIVE);
-	HASHACTION action = check_hash_fullness(active_tables_map, diskquota_max_active_tables, active_tables_map_warning,
-	                                        &active_tables_map_last_overflow_report);
-	entry             = hash_search(active_tables_map, &item, action, &found);
+	HASHACTION action =
+	        check_hash_fullness(diskquota_locks.active_table_lock, active_tables_map, diskquota_max_active_tables,
+	                            active_tables_map_warning, &active_tables_map_last_overflow_report);
+	entry = hash_search(active_tables_map, &item, action, &found);
 	if (entry && !found) *entry = item;
 
 	LWLockRelease(diskquota_locks.active_table_lock);
@@ -835,8 +837,9 @@ get_active_tables_oid(void)
 	hash_seq_init(&iter, local_active_table_file_map);
 	while ((active_table_file_entry = (DiskQuotaActiveTableFileEntry *)hash_seq_search(&iter)) != NULL)
 	{
-		HASHACTION action = check_hash_fullness(active_tables_map, diskquota_max_active_tables,
-		                                        active_tables_map_warning, &active_tables_map_last_overflow_report);
+		HASHACTION action =
+		        check_hash_fullness(diskquota_locks.active_table_lock, active_tables_map, diskquota_max_active_tables,
+		                            active_tables_map_warning, &active_tables_map_last_overflow_report);
 		hash_search(active_tables_map, active_table_file_entry, action, NULL);
 	}
 	/* TODO: hash_seq_term(&iter); */
@@ -899,8 +902,9 @@ get_active_tables_oid(void)
 		LWLockAcquire(diskquota_locks.active_table_lock, LW_EXCLUSIVE);
 		while ((active_table_file_entry = (DiskQuotaActiveTableFileEntry *)hash_seq_search(&iter)) != NULL)
 		{
-			HASHACTION action = check_hash_fullness(active_tables_map, diskquota_max_active_tables,
-			                                        active_tables_map_warning, &active_tables_map_last_overflow_report);
+			HASHACTION action = check_hash_fullness(diskquota_locks.active_table_lock, active_tables_map,
+			                                        diskquota_max_active_tables, active_tables_map_warning,
+			                                        &active_tables_map_last_overflow_report);
 			entry             = hash_search(active_tables_map, active_table_file_entry, action, &found);
 			if (entry) *entry = *active_table_file_entry;
 		}

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -346,6 +346,7 @@ refresh_quota_info_map(void)
 	HASH_SEQ_STATUS iter;
 	QuotaInfoEntry *entry;
 
+	LWLockAcquire(diskquota_locks.local_disk_quota_reject_map_lock, LW_EXCLUSIVE);
 	hash_seq_init(&iter, quota_info_map);
 	while ((entry = hash_seq_search(&iter)) != NULL)
 	{
@@ -379,6 +380,7 @@ refresh_quota_info_map(void)
 			}
 		}
 	}
+	LWLockRelease(diskquota_locks.local_disk_quota_reject_map_lock);
 }
 
 /* transfer one table's size from one quota to another quota */
@@ -1495,6 +1497,7 @@ do_load_quotas(void)
 	}
 
 	bool cleanConfigTables = false;
+	LWLockAcquire(diskquota_locks.quota_info_map_lock, LW_EXCLUSIVE);
 	for (i = 0; i < SPI_processed; i++)
 	{
 		HeapTuple tup = SPI_tuptable->vals[i];
@@ -1554,6 +1557,7 @@ do_load_quotas(void)
 				cleanConfigTables = true;
 		}
 	}
+	LWLockRelease(diskquota_locks.quota_info_map_lock);
 
 	if (cleanConfigTables)
 	{

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -385,8 +385,10 @@ refresh_quota_info_map(void)
 static void
 transfer_table_for_quota(int64 totalsize, QuotaType type, Oid *old_keys, Oid *new_keys, int16 segid)
 {
+	LWLockAcquire(diskquota_locks.quota_info_map_lock, LW_EXCLUSIVE);
 	update_size_for_quota(-totalsize, type, old_keys, segid);
 	update_size_for_quota(totalsize, type, new_keys, segid);
+	LWLockRelease(diskquota_locks.quota_info_map_lock);
 }
 
 static void
@@ -938,6 +940,7 @@ get_table_size_map_entry(Oid oid, int16 segid)
 void
 calculate_active_table_disk_usage(Oid oid, int64 size, int16 segid)
 {
+	LWLockAcquire(diskquota_locks.table_size_map_lock, LW_EXCLUSIVE);
 	TableSizeEntry *tsentry = get_table_size_map_entry(oid, segid);
 
 	if (tsentry == NULL)
@@ -945,6 +948,7 @@ calculate_active_table_disk_usage(Oid oid, int64 size, int16 segid)
 		/* Too many tables have been added to the table_size_map, to avoid diskquota using
 		   too much share memory, just return. The diskquota won't work correctly
 		   anymore. */
+		LWLockRelease(diskquota_locks.table_size_map_lock);
 		return;
 	}
 
@@ -968,12 +972,15 @@ calculate_active_table_disk_usage(Oid oid, int64 size, int16 segid)
 
 	/* update the disk usage, there may be entries in the map whose keys are InvlidOid as the tsentry does
 	 * not exist in the table_size_map */
+	LWLockAcquire(diskquota_locks.quota_info_map_lock, LW_EXCLUSIVE);
 	update_size_for_quota(updated_total_size, NAMESPACE_QUOTA, (Oid[]){tsentry->namespaceoid}, segid);
 	update_size_for_quota(updated_total_size, ROLE_QUOTA, (Oid[]){tsentry->owneroid}, segid);
 	update_size_for_quota(updated_total_size, ROLE_TABLESPACE_QUOTA, (Oid[]){tsentry->owneroid, tsentry->tablespaceoid},
 	                      segid);
 	update_size_for_quota(updated_total_size, NAMESPACE_TABLESPACE_QUOTA,
 	                      (Oid[]){tsentry->namespaceoid, tsentry->tablespaceoid}, segid);
+	LWLockRelease(diskquota_locks.quota_info_map_lock);
+	LWLockRelease(diskquota_locks.table_size_map_lock);
 }
 
 /*
@@ -1055,6 +1062,7 @@ track_namespace_owner_tablespace_changes(bool is_init)
 		 * and the content id is continuous, so it's safe to use SEGCOUNT
 		 * to get segid.
 		 */
+		LWLockAcquire(diskquota_locks.table_size_map_lock, LW_EXCLUSIVE);
 		for (int cur_segid = -1; cur_segid < SEGCOUNT; cur_segid++)
 		{
 			tsentry = get_table_size_map_entry(relOid, cur_segid);
@@ -1109,6 +1117,7 @@ track_namespace_owner_tablespace_changes(bool is_init)
 				tsentry->tablespaceoid = reltablespace;
 			}
 		}
+		LWLockRelease(diskquota_locks.table_size_map_lock);
 		if (HeapTupleIsValid(classTup))
 		{
 			heap_freetuple(classTup);
@@ -1130,6 +1139,7 @@ track_namespace_owner_tablespace_changes(bool is_init)
 			int seg_ed = TableSizeEntrySegidEnd(tsentry);
 			for (int i = seg_st; i < seg_ed; i++)
 			{
+				LWLockAcquire(diskquota_locks.quota_info_map_lock, LW_EXCLUSIVE);
 				update_size_for_quota(-TableSizeEntryGetSize(tsentry, i), NAMESPACE_QUOTA,
 				                      (Oid[]){tsentry->namespaceoid}, i);
 				update_size_for_quota(-TableSizeEntryGetSize(tsentry, i), ROLE_QUOTA, (Oid[]){tsentry->owneroid}, i);
@@ -1137,6 +1147,7 @@ track_namespace_owner_tablespace_changes(bool is_init)
 				                      (Oid[]){tsentry->owneroid, tsentry->tablespaceoid}, i);
 				update_size_for_quota(-TableSizeEntryGetSize(tsentry, i), NAMESPACE_TABLESPACE_QUOTA,
 				                      (Oid[]){tsentry->namespaceoid, tsentry->tablespaceoid}, i);
+				LWLockRelease(diskquota_locks.quota_info_map_lock);
 			}
 		}
 	}

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -264,8 +264,8 @@ update_size_for_quota(int64 size, QuotaType type, Oid *keys, int16 segid)
 	memcpy(key.keys, keys, quota_key_num[type] * sizeof(Oid));
 	key.type  = type;
 	key.segid = segid;
-	action    = check_hash_fullness(quota_info_map, diskquota_max_quota_probes, quota_info_map_warning,
-	                                quota_info_map_last_overflow_report);
+	action    = check_hash_fullness(diskquota_locks.quota_info_map_lock, quota_info_map, diskquota_max_quota_probes,
+	                                quota_info_map_warning, quota_info_map_last_overflow_report);
 	entry     = hash_search(quota_info_map, &key, action, &found);
 	/* If the number of quota exceeds the limit, entry will be NULL */
 	if (entry == NULL) return;
@@ -291,8 +291,8 @@ update_limit_for_quota(int64 limit, float segratio, QuotaType type, Oid *keys)
 		memcpy(key.keys, keys, quota_key_num[type] * sizeof(Oid));
 		key.type  = type;
 		key.segid = i;
-		action    = check_hash_fullness(quota_info_map, diskquota_max_quota_probes, quota_info_map_warning,
-		                                quota_info_map_last_overflow_report);
+		action    = check_hash_fullness(diskquota_locks.quota_info_map_lock, quota_info_map, diskquota_max_quota_probes,
+		                                quota_info_map_warning, quota_info_map_last_overflow_report);
 		entry     = hash_search(quota_info_map, &key, action, &found);
 		/* If the number of quota exceeds the limit, entry will be NULL */
 		if (entry == NULL) continue;
@@ -322,8 +322,9 @@ add_quota_to_rejectmap(QuotaType type, Oid targetOid, Oid tablespaceoid, bool se
 	keyitem.tablespaceoid = tablespaceoid;
 	keyitem.targettype    = (uint32)type;
 	HASHACTION action =
-	        check_hash_fullness(local_disk_quota_reject_map, diskquota_max_local_reject_entries,
-	                            local_disk_quota_reject_map_warning, local_disk_quota_reject_map_last_overflow_report);
+	        check_hash_fullness(diskquota_locks.local_disk_quota_reject_map_lock, local_disk_quota_reject_map,
+	                            diskquota_max_local_reject_entries, local_disk_quota_reject_map_warning,
+	                            local_disk_quota_reject_map_last_overflow_report);
 	localrejectentry = hash_search(local_disk_quota_reject_map, &keyitem, action, NULL);
 	if (localrejectentry)
 	{
@@ -488,26 +489,32 @@ static void
 init_lwlocks(void)
 {
 #if GP_VERSION_NUM < 70000
-	diskquota_locks.active_table_lock          = LWLockAssign();
-	diskquota_locks.reject_map_lock            = LWLockAssign();
-	diskquota_locks.extension_ddl_message_lock = LWLockAssign();
-	diskquota_locks.extension_ddl_lock         = LWLockAssign();
-	diskquota_locks.monitored_dbid_cache_lock  = LWLockAssign();
-	diskquota_locks.relation_cache_lock        = LWLockAssign();
-	diskquota_locks.dblist_lock                = LWLockAssign();
-	diskquota_locks.workerlist_lock            = LWLockAssign();
-	diskquota_locks.altered_reloid_cache_lock  = LWLockAssign();
+	diskquota_locks.active_table_lock                = LWLockAssign();
+	diskquota_locks.reject_map_lock                  = LWLockAssign();
+	diskquota_locks.extension_ddl_message_lock       = LWLockAssign();
+	diskquota_locks.extension_ddl_lock               = LWLockAssign();
+	diskquota_locks.monitored_dbid_cache_lock        = LWLockAssign();
+	diskquota_locks.relation_cache_lock              = LWLockAssign();
+	diskquota_locks.dblist_lock                      = LWLockAssign();
+	diskquota_locks.workerlist_lock                  = LWLockAssign();
+	diskquota_locks.altered_reloid_cache_lock        = LWLockAssign();
+	diskquota_locks.quota_info_map_lock              = LWLockAssign();
+	diskquota_locks.table_size_map_lock              = LWLockAssign();
+	diskquota_locks.local_disk_quota_reject_map_lock = LWLockAssign();
 #else
-	LWLockPadded *lock_base                    = GetNamedLWLockTranche("DiskquotaLocks");
-	diskquota_locks.active_table_lock          = &lock_base[0].lock;
-	diskquota_locks.reject_map_lock            = &lock_base[1].lock;
-	diskquota_locks.extension_ddl_message_lock = &lock_base[2].lock;
-	diskquota_locks.extension_ddl_lock         = &lock_base[3].lock;
-	diskquota_locks.monitored_dbid_cache_lock  = &lock_base[4].lock;
-	diskquota_locks.relation_cache_lock        = &lock_base[5].lock;
-	diskquota_locks.dblist_lock                = &lock_base[6].lock;
-	diskquota_locks.workerlist_lock            = &lock_base[7].lock;
-	diskquota_locks.altered_reloid_cache_lock  = &lock_base[8].lock;
+	LWLockPadded *lock_base                          = GetNamedLWLockTranche("DiskquotaLocks");
+	diskquota_locks.active_table_lock                = &lock_base[0].lock;
+	diskquota_locks.reject_map_lock                  = &lock_base[1].lock;
+	diskquota_locks.extension_ddl_message_lock       = &lock_base[2].lock;
+	diskquota_locks.extension_ddl_lock               = &lock_base[3].lock;
+	diskquota_locks.monitored_dbid_cache_lock        = &lock_base[4].lock;
+	diskquota_locks.relation_cache_lock              = &lock_base[5].lock;
+	diskquota_locks.dblist_lock                      = &lock_base[6].lock;
+	diskquota_locks.workerlist_lock                  = &lock_base[7].lock;
+	diskquota_locks.altered_reloid_cache_lock        = &lock_base[8].lock;
+	diskquota_locks.quota_info_map_lock              = &lock_base[9].lock;
+	diskquota_locks.table_size_map_lock              = &lock_base[10].lock;
+	diskquota_locks.local_disk_quota_reject_map_lock = &lock_base[11].lock;
 #endif /* GP_VERSION_NUM */
 }
 
@@ -902,10 +909,11 @@ static TableSizeEntry *
 get_table_size_map_entry(Oid oid, int16 segid)
 {
 	bool              found;
-	TableSizeEntryKey key     = {.reloid = oid, .id = TableSizeEntryId(segid)};
-	HASHACTION        action  = check_hash_fullness(table_size_map, MAX_NUM_TABLE_SIZE_ENTRIES, table_size_map_warning,
-	                                                table_size_map_last_overflow_report);
-	TableSizeEntry   *tsentry = hash_search(table_size_map, &key, action, &found);
+	TableSizeEntryKey key = {.reloid = oid, .id = TableSizeEntryId(segid)};
+	HASHACTION        action =
+	        check_hash_fullness(diskquota_locks.table_size_map_lock, table_size_map, MAX_NUM_TABLE_SIZE_ENTRIES,
+	                            table_size_map_warning, table_size_map_last_overflow_report);
+	TableSizeEntry *tsentry = hash_search(table_size_map, &key, action, &found);
 
 	if (!found && tsentry != NULL)
 	{
@@ -1288,10 +1296,10 @@ flush_local_reject_map(void)
 		 */
 		if (localrejectentry->isexceeded)
 		{
-			HASHACTION action =
-			        check_hash_fullness(disk_quota_reject_map, MAX_DISK_QUOTA_REJECT_ENTRIES,
-			                            disk_quota_reject_map_warning, &disk_quota_reject_map_last_overflow_report);
-			rejectentry = hash_search(disk_quota_reject_map, &localrejectentry->keyitem, action, &found);
+			HASHACTION action = check_hash_fullness(diskquota_locks.reject_map_lock, disk_quota_reject_map,
+			                                        MAX_DISK_QUOTA_REJECT_ENTRIES, disk_quota_reject_map_warning,
+			                                        &disk_quota_reject_map_last_overflow_report);
+			rejectentry       = hash_search(disk_quota_reject_map, &localrejectentry->keyitem, action, &found);
 			if (rejectentry == NULL)
 			{
 				continue;
@@ -2165,10 +2173,10 @@ refresh_rejectmap(PG_FUNCTION_ARGS)
 		 */
 		if (OidIsValid(rejectmapentry->keyitem.targetoid)) continue;
 
-		HASHACTION action =
-		        check_hash_fullness(disk_quota_reject_map, MAX_DISK_QUOTA_REJECT_ENTRIES, disk_quota_reject_map_warning,
-		                            &disk_quota_reject_map_last_overflow_report);
-		new_entry = hash_search(disk_quota_reject_map, &rejectmapentry->keyitem, action, &found);
+		HASHACTION action = check_hash_fullness(diskquota_locks.reject_map_lock, disk_quota_reject_map,
+		                                        MAX_DISK_QUOTA_REJECT_ENTRIES, disk_quota_reject_map_warning,
+		                                        &disk_quota_reject_map_last_overflow_report);
+		new_entry         = hash_search(disk_quota_reject_map, &rejectmapentry->keyitem, action, &found);
 		if (!found && new_entry) memcpy(new_entry, rejectmapentry, sizeof(GlobalRejectMapEntry));
 	}
 	LWLockRelease(diskquota_locks.reject_map_lock);

--- a/src/relation_cache.c
+++ b/src/relation_cache.c
@@ -189,8 +189,8 @@ update_relation_cache(Oid relid)
 
 	LWLockAcquire(diskquota_locks.relation_cache_lock, LW_EXCLUSIVE);
 
-	action         = check_hash_fullness(relation_cache, diskquota_max_active_tables, relation_cache_warning,
-	                                     &active_tables_map_last_overflow_report);
+	action = check_hash_fullness(diskquota_locks.relation_cache_lock, relation_cache, diskquota_max_active_tables,
+	                             relation_cache_warning, &active_tables_map_last_overflow_report);
 	relation_entry = hash_search(relation_cache, &relation_entry_data.relid, action, NULL);
 
 	if (relation_entry == NULL)
@@ -200,8 +200,8 @@ update_relation_cache(Oid relid)
 	}
 	memcpy(relation_entry, &relation_entry_data, sizeof(DiskQuotaRelationCacheEntry));
 
-	action      = check_hash_fullness(relid_cache, diskquota_max_active_tables, relid_cache_warning,
-	                                  &active_tables_map_last_overflow_report);
+	action      = check_hash_fullness(diskquota_locks.relation_cache_lock, relid_cache, diskquota_max_active_tables,
+	                                  relid_cache_warning, &active_tables_map_last_overflow_report);
 	relid_entry = hash_search(relid_cache, &relid_entry_data.relfilenode, action, NULL);
 	if (relid_entry == NULL)
 	{


### PR DESCRIPTION
Add locks when using shared hashmaps

When using shared hashmaps, table_size_map, quota_info_map, and
local_disk_quota_reject_map, the check_hash_fullness function does not acquire
any locks. Add locks and an assertion to verify that this is working.