### PR TITLE
ADBDEV-8922: Restore old logic for limiting sizes of table_size and quota_info_map

### DIFF
--- a/src/diskquota.c
+++ b/src/diskquota.c
@@ -91,6 +91,12 @@ static DiskQuotaWorkerEntry *volatile MyWorkerInfo = NULL;
 // how many database diskquota are monitoring on
 static int num_db = 0;
 
+/* how many TableSizeEntry are maintained in all the table_size_map in shared memory*/
+pg_atomic_uint32 *diskquota_table_size_entry_num;
+
+/* how many QuotaInfoEntry are maintained in all the quota_info_map in shared memory*/
+pg_atomic_uint32 *diskquota_quota_info_entry_num;
+
 static DiskquotaLauncherShmemStruct *DiskquotaLauncherShmem;
 
 #define MIN_SLEEPTIME 100         /* milliseconds */
@@ -1772,6 +1778,15 @@ init_launcher_shmem()
 			DiskquotaLauncherShmem->dbArray[i].workerId = INVALID_WORKER_ID;
 		}
 	}
+	/* init TableSizeEntry counter */
+	diskquota_table_size_entry_num =
+	        ShmemInitStruct("diskquota TableSizeEntry counter", sizeof(pg_atomic_uint32), &found);
+	if (!found) pg_atomic_init_u32(diskquota_table_size_entry_num, 0);
+
+	/* init QuotaInfoEntry counter */
+	diskquota_quota_info_entry_num =
+	        ShmemInitStruct("diskquota QuotaInfoEntry counter", sizeof(pg_atomic_uint32), &found);
+	if (!found) pg_atomic_init_u32(diskquota_quota_info_entry_num, 0);
 }
 
 /*

--- a/src/diskquota.h
+++ b/src/diskquota.h
@@ -319,6 +319,8 @@ extern HTAB *DiskquotaShmemInitHash(const char *name, long init_size, long max_s
 extern void  refresh_monitored_dbid_cache(void);
 extern HASHACTION check_hash_fullness(HTAB *hashp, int max_size, const char *warning_message,
                                       TimestampTz *last_overflow_report);
+extern HASHACTION check_hash_fullness_num(HTAB *hashp, pg_atomic_uint32 *counter, int max_size,
+                                          const char *warning_message, TimestampTz *last_overflow_report);
 bool              SPI_push_cond_and_connect(void);
 void              SPI_finish_and_pop_cond(bool pushed);
 #endif

--- a/src/diskquota_utility.c
+++ b/src/diskquota_utility.c
@@ -1681,6 +1681,33 @@ check_hash_fullness(HTAB *hashp, int max_size, const char *warning_message, Time
 	return HASH_FIND;
 }
 
+HASHACTION
+check_hash_fullness_num(HTAB *hashp, pg_atomic_uint32 *counter, int max_size, const char *warning_message,
+                        TimestampTz *last_overflow_report)
+{
+	uint32 num_entries = pg_atomic_read_u32(counter);
+
+	if (num_entries < max_size)
+	{
+		(void)pg_atomic_add_fetch_u32(counter, 1);
+		return HASH_ENTER;
+	}
+
+	if (num_entries == max_size)
+	{
+		TimestampTz current_time = GetCurrentTimestamp();
+
+		if (*last_overflow_report == 0 || TimestampDifferenceExceeds(*last_overflow_report, current_time,
+		                                                             diskquota_hashmap_overflow_report_timeout * 1000))
+		{
+			ereport(WARNING, (errmsg("[diskquota] %s", warning_message)));
+			*last_overflow_report = current_time;
+		}
+	}
+
+	return HASH_FIND;
+}
+
 bool
 SPI_push_cond_and_connect(void)
 {

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -84,6 +84,9 @@ extern int diskquota_max_table_segments;
 extern int diskquota_max_monitored_databases;
 extern int diskquota_max_quota_probes;
 extern int diskquota_max_local_reject_entries;
+
+extern pg_atomic_uint32 *diskquota_table_size_entry_num;
+extern pg_atomic_uint32 *diskquota_quota_info_entry_num;
 /*
  * local cache of table disk size and corresponding schema and owner.
  *
@@ -264,8 +267,8 @@ update_size_for_quota(int64 size, QuotaType type, Oid *keys, int16 segid)
 	memcpy(key.keys, keys, quota_key_num[type] * sizeof(Oid));
 	key.type  = type;
 	key.segid = segid;
-	action    = check_hash_fullness(quota_info_map, diskquota_max_quota_probes, quota_info_map_warning,
-	                                quota_info_map_last_overflow_report);
+	action    = check_hash_fullness_num(quota_info_map, diskquota_quota_info_entry_num, diskquota_max_quota_probes,
+	                                    quota_info_map_warning, quota_info_map_last_overflow_report);
 	entry     = hash_search(quota_info_map, &key, action, &found);
 	/* If the number of quota exceeds the limit, entry will be NULL */
 	if (entry == NULL) return;
@@ -291,8 +294,8 @@ update_limit_for_quota(int64 limit, float segratio, QuotaType type, Oid *keys)
 		memcpy(key.keys, keys, quota_key_num[type] * sizeof(Oid));
 		key.type  = type;
 		key.segid = i;
-		action    = check_hash_fullness(quota_info_map, diskquota_max_quota_probes, quota_info_map_warning,
-		                                quota_info_map_last_overflow_report);
+		action    = check_hash_fullness_num(quota_info_map, diskquota_quota_info_entry_num, diskquota_max_quota_probes,
+		                                    quota_info_map_warning, quota_info_map_last_overflow_report);
 		entry     = hash_search(quota_info_map, &key, action, &found);
 		/* If the number of quota exceeds the limit, entry will be NULL */
 		if (entry == NULL) continue;
@@ -356,6 +359,7 @@ refresh_quota_info_map(void)
 			if (!HeapTupleIsValid(tuple))
 			{
 				hash_search(quota_info_map, &entry->key, HASH_REMOVE, NULL);
+				pg_atomic_fetch_sub_u32(diskquota_quota_info_entry_num, 1);
 				removed = true;
 				break;
 			}
@@ -545,6 +549,8 @@ DiskQuotaShmemSize(void)
 	if (IS_QUERY_DISPATCHER())
 	{
 		size = add_size(size, diskquota_launcher_shmem_size());
+		size = add_size(size, sizeof(pg_atomic_uint32)); // diskquota_table_size_entry_num
+		size = add_size(size, sizeof(pg_atomic_uint32)); // diskquota_quota_info_entry_num
 		size = add_size(size, diskquota_worker_shmem_size() * diskquota_max_monitored_databases);
 	}
 
@@ -637,6 +643,7 @@ vacuum_disk_quota_model(uint32 id)
 	while ((tsentry = hash_seq_search(&iter)) != NULL)
 	{
 		hash_search(table_size_map, &tsentry->key, HASH_REMOVE, NULL);
+		pg_atomic_fetch_sub_u32(diskquota_table_size_entry_num, 1);
 	}
 
 	format_name("TableSizeEntrymap_last_overflow_report", id, &str);
@@ -670,6 +677,7 @@ vacuum_disk_quota_model(uint32 id)
 	while ((qentry = hash_seq_search(&iter)) != NULL)
 	{
 		hash_search(quota_info_map, &qentry->key, HASH_REMOVE, NULL);
+		pg_atomic_fetch_sub_u32(diskquota_quota_info_entry_num, 1);
 	}
 	format_name("QuotaInfoMap_last_overflow_report", id, &str);
 	quota_info_map_last_overflow_report = ShmemInitStruct(str.data, sizeof(TimestampTz), &found);
@@ -902,10 +910,11 @@ static TableSizeEntry *
 get_table_size_map_entry(Oid oid, int16 segid)
 {
 	bool              found;
-	TableSizeEntryKey key     = {.reloid = oid, .id = TableSizeEntryId(segid)};
-	HASHACTION        action  = check_hash_fullness(table_size_map, MAX_NUM_TABLE_SIZE_ENTRIES, table_size_map_warning,
-	                                                table_size_map_last_overflow_report);
-	TableSizeEntry   *tsentry = hash_search(table_size_map, &key, action, &found);
+	TableSizeEntryKey key = {.reloid = oid, .id = TableSizeEntryId(segid)};
+	HASHACTION        action =
+	        check_hash_fullness_num(table_size_map, diskquota_table_size_entry_num, MAX_NUM_TABLE_SIZE_ENTRIES,
+	                                table_size_map_warning, table_size_map_last_overflow_report);
+	TableSizeEntry *tsentry = hash_search(table_size_map, &key, action, &found);
 
 	if (!found && tsentry != NULL)
 	{
@@ -1242,6 +1251,7 @@ flush_to_table_size(void)
 		if (!get_table_size_entry_flag(tsentry, TABLE_EXIST))
 		{
 			hash_search(table_size_map, &tsentry->key, HASH_REMOVE, NULL);
+			pg_atomic_fetch_sub_u32(diskquota_table_size_entry_num, 1);
 		}
 	}
 


### PR DESCRIPTION
Restore old logic for limiting sizes of table_size and quota_info_map

After commit 2862042, shared hashmaps table_size_map and quota_info_map may
overflow because their limit is set per database, while they are allocated
cluster-wide. Revert the logic for limiting them per cluster using atomics.

Tests are not provided because it is quite difficult to exhaust shared memory
without exceeding the per-database limit.

Ticket: ADBDEV-8922