### PR TITLE
ADBDEV-8953: Fix shared memory allocation and usage in diskquota

### DIFF
--- a/src/diskquota.c
+++ b/src/diskquota.c
@@ -1130,7 +1130,7 @@ process_extension_ddl_message()
 	ExtensionDDLMessage local_extension_ddl_message;
 
 	LWLockAcquire(diskquota_locks.extension_ddl_message_lock, LW_SHARED);
-	memcpy(&local_extension_ddl_message, extension_ddl_message, sizeof(ExtensionDDLMessage));
+	memcpy(&local_extension_ddl_message, extension_ddl_message, EXTENSION_DDL_MESSAGE_SIZE);
 	LWLockRelease(diskquota_locks.extension_ddl_message_lock);
 
 	/* create/drop extension message must be valid */
@@ -1146,7 +1146,7 @@ process_extension_ddl_message()
 
 	/* Send createdrop extension diskquota result back to QD */
 	LWLockAcquire(diskquota_locks.extension_ddl_message_lock, LW_EXCLUSIVE);
-	memset(extension_ddl_message, 0, sizeof(ExtensionDDLMessage));
+	memset(extension_ddl_message, 0, EXTENSION_DDL_MESSAGE_SIZE);
 	extension_ddl_message->launcher_pid = MyProcPid;
 	extension_ddl_message->result       = (int)code;
 	LWLockRelease(diskquota_locks.extension_ddl_message_lock);

--- a/src/diskquota.c
+++ b/src/diskquota.c
@@ -1732,8 +1732,8 @@ void
 init_launcher_shmem()
 {
 	bool found;
-	DiskquotaLauncherShmem = (DiskquotaLauncherShmemStruct *)DiskquotaShmemInitStruct("Diskquota launcher Data",
-	                                                                         diskquota_launcher_shmem_size(), &found);
+	DiskquotaLauncherShmem = (DiskquotaLauncherShmemStruct *)DiskquotaShmemInitStruct(
+	        "Diskquota launcher Data", diskquota_launcher_shmem_size(), &found);
 
 	memset(DiskquotaLauncherShmem, 0, diskquota_launcher_shmem_size());
 	if (!found)

--- a/src/diskquota.c
+++ b/src/diskquota.c
@@ -1732,8 +1732,8 @@ void
 init_launcher_shmem()
 {
 	bool found;
-	DiskquotaLauncherShmem = (DiskquotaLauncherShmemStruct *)ShmemInitStruct("Diskquota launcher Data",
-	                                                                         diskquota_launcher_shmem_size(), &found);
+	DiskquotaLauncherShmem = (DiskquotaLauncherShmemStruct *)DiskquotaShmemInitStruct(
+	        "Diskquota launcher Data", diskquota_launcher_shmem_size(), &found);
 	memset(DiskquotaLauncherShmem, 0, diskquota_launcher_shmem_size());
 	if (!found)
 	{

--- a/src/diskquota.c
+++ b/src/diskquota.c
@@ -1741,7 +1741,6 @@ init_launcher_shmem()
 
 #ifdef USE_ASSERT_CHECKING
 	if (!found) pg_atomic_sub_fetch_u32(diskquota_shmem_size, diskquota_launcher_shmem_size());
-	if (found) elog(WARNING, "DiskquotaLauncherShmem found!");
 #endif
 
 	memset(DiskquotaLauncherShmem, 0, diskquota_launcher_shmem_size());

--- a/src/diskquota.c
+++ b/src/diskquota.c
@@ -1732,8 +1732,8 @@ void
 init_launcher_shmem()
 {
 	bool found;
-	DiskquotaLauncherShmem = (DiskquotaLauncherShmemStruct *)DiskquotaShmemInitStruct(
-	        "Diskquota launcher Data", diskquota_launcher_shmem_size(), &found);
+	DiskquotaLauncherShmem = (DiskquotaLauncherShmemStruct *)ShmemInitStruct("Diskquota launcher Data",
+	                                                                         diskquota_launcher_shmem_size(), &found);
 
 	memset(DiskquotaLauncherShmem, 0, diskquota_launcher_shmem_size());
 	if (!found)

--- a/src/diskquota.c
+++ b/src/diskquota.c
@@ -91,7 +91,10 @@ static DiskQuotaWorkerEntry *volatile MyWorkerInfo = NULL;
 // how many database diskquota are monitoring on
 static int num_db = 0;
 
-DiskquotaLauncherShmemStruct *DiskquotaLauncherShmem = NULL;
+#ifndef USE_ASSERT_CHECKING
+static
+#endif
+        DiskquotaLauncherShmemStruct *DiskquotaLauncherShmem = NULL;
 
 #define MIN_SLEEPTIME 100         /* milliseconds */
 #define BGWORKER_LOG_TIME 3600000 /* milliseconds */

--- a/src/diskquota.c
+++ b/src/diskquota.c
@@ -106,7 +106,7 @@ static DiskquotaLauncherShmemStruct *DiskquotaLauncherShmem;
 BackgroundWorkerHandle **bgworker_handles;
 
 #ifdef USE_ASSERT_CHECKING
-extern pg_atomic_uint32 *diskquota_shmem_size;
+extern pg_atomic_uint64 *diskquota_shmem_size;
 #endif
 
 typedef enum
@@ -1740,7 +1740,7 @@ init_launcher_shmem()
 	                                                                         diskquota_launcher_shmem_size(), &found);
 
 #ifdef USE_ASSERT_CHECKING
-	if (!found) pg_atomic_sub_fetch_u32(diskquota_shmem_size, diskquota_launcher_shmem_size());
+	if (!found) pg_atomic_sub_fetch_u64(diskquota_shmem_size, diskquota_launcher_shmem_size());
 #endif
 
 	memset(DiskquotaLauncherShmem, 0, diskquota_launcher_shmem_size());

--- a/src/diskquota.c
+++ b/src/diskquota.c
@@ -86,7 +86,7 @@ ExtensionDDLMessage *extension_ddl_message = NULL;
 
 // Only access in diskquota worker, different from each worker.
 // a pointer to DiskquotaLauncherShmem->workerEntries in shared memory
-DiskQuotaWorkerEntry *volatile MyWorkerInfo = NULL;
+static DiskQuotaWorkerEntry *volatile MyWorkerInfo = NULL;
 
 // how many database diskquota are monitoring on
 static int num_db = 0;

--- a/src/diskquota.c
+++ b/src/diskquota.c
@@ -105,6 +105,10 @@ static DiskquotaLauncherShmemStruct *DiskquotaLauncherShmem;
  */
 BackgroundWorkerHandle **bgworker_handles;
 
+#ifdef USE_ASSERT_CHECKING
+extern pg_atomic_uint32 *diskquota_shmem_size;
+#endif
+
 typedef enum
 {
 	SUCCESS,
@@ -1734,6 +1738,12 @@ init_launcher_shmem()
 	bool found;
 	DiskquotaLauncherShmem = (DiskquotaLauncherShmemStruct *)ShmemInitStruct("Diskquota launcher Data",
 	                                                                         diskquota_launcher_shmem_size(), &found);
+
+#ifdef USE_ASSERT_CHECKING
+	if (!found) pg_atomic_sub_fetch_u32(diskquota_shmem_size, diskquota_launcher_shmem_size());
+	if (found) elog(WARNING, "DiskquotaLauncherShmem found!");
+#endif
+
 	memset(DiskquotaLauncherShmem, 0, diskquota_launcher_shmem_size());
 	if (!found)
 	{

--- a/src/diskquota.c
+++ b/src/diskquota.c
@@ -105,10 +105,6 @@ static DiskquotaLauncherShmemStruct *DiskquotaLauncherShmem;
  */
 BackgroundWorkerHandle **bgworker_handles;
 
-#ifdef USE_ASSERT_CHECKING
-extern pg_atomic_uint64 *diskquota_shmem_size;
-#endif
-
 typedef enum
 {
 	SUCCESS,
@@ -1736,12 +1732,8 @@ void
 init_launcher_shmem()
 {
 	bool found;
-	DiskquotaLauncherShmem = (DiskquotaLauncherShmemStruct *)ShmemInitStruct("Diskquota launcher Data",
+	DiskquotaLauncherShmem = (DiskquotaLauncherShmemStruct *)DiskquotaShmemInitStruct("Diskquota launcher Data",
 	                                                                         diskquota_launcher_shmem_size(), &found);
-
-#ifdef USE_ASSERT_CHECKING
-	if (!found) pg_atomic_sub_fetch_u64(diskquota_shmem_size, diskquota_launcher_shmem_size());
-#endif
 
 	memset(DiskquotaLauncherShmem, 0, diskquota_launcher_shmem_size());
 	if (!found)

--- a/src/diskquota.c
+++ b/src/diskquota.c
@@ -1734,7 +1734,6 @@ init_launcher_shmem()
 	bool found;
 	DiskquotaLauncherShmem = (DiskquotaLauncherShmemStruct *)ShmemInitStruct("Diskquota launcher Data",
 	                                                                         diskquota_launcher_shmem_size(), &found);
-
 	memset(DiskquotaLauncherShmem, 0, diskquota_launcher_shmem_size());
 	if (!found)
 	{

--- a/src/diskquota.c
+++ b/src/diskquota.c
@@ -86,12 +86,12 @@ ExtensionDDLMessage *extension_ddl_message = NULL;
 
 // Only access in diskquota worker, different from each worker.
 // a pointer to DiskquotaLauncherShmem->workerEntries in shared memory
-static DiskQuotaWorkerEntry *volatile MyWorkerInfo = NULL;
+DiskQuotaWorkerEntry *volatile MyWorkerInfo = NULL;
 
 // how many database diskquota are monitoring on
 static int num_db = 0;
 
-static DiskquotaLauncherShmemStruct *DiskquotaLauncherShmem;
+DiskquotaLauncherShmemStruct *DiskquotaLauncherShmem = NULL;
 
 #define MIN_SLEEPTIME 100         /* milliseconds */
 #define BGWORKER_LOG_TIME 3600000 /* milliseconds */

--- a/src/diskquota.c
+++ b/src/diskquota.c
@@ -91,10 +91,7 @@ static DiskQuotaWorkerEntry *volatile MyWorkerInfo = NULL;
 // how many database diskquota are monitoring on
 static int num_db = 0;
 
-#ifndef USE_ASSERT_CHECKING
-static
-#endif
-        DiskquotaLauncherShmemStruct *DiskquotaLauncherShmem = NULL;
+DiskquotaLauncherShmemStruct *DiskquotaLauncherShmem = NULL;
 
 #define MIN_SLEEPTIME 100         /* milliseconds */
 #define BGWORKER_LOG_TIME 3600000 /* milliseconds */

--- a/src/diskquota.h
+++ b/src/diskquota.h
@@ -78,6 +78,7 @@ extern int diskquota_worker_timeout;
 #define EXTENSION_DDL_MESSAGE_SIZE sizeof(ExtensionDDLMessage)
 #define ACTIVE_TABLES_MAP_ENTRY_SIZE sizeof(DiskQuotaActiveTableFileEntry)
 #define RELATION_CACHE_ENTRY_SIZE sizeof(DiskQuotaRelationCacheEntry)
+#define RELID_CACHE_ENTRY_SIZE sizeof(DiskQuotaRelidCacheEntry)
 
 typedef enum
 {

--- a/src/diskquota.h
+++ b/src/diskquota.h
@@ -314,6 +314,7 @@ extern void         diskquota_stop_worker(void);
 extern void         update_monitordb_status(Oid dbid, uint32 status);
 extern HTAB        *diskquota_hash_create(const char *tabname, long nelem, HASHCTL *info, int flags,
                                           DiskquotaHashFunction hashFunction);
+extern void *DiskquotaShmemInitStruct(const char *name, Size size, bool *foundPtr);
 extern HTAB *DiskquotaShmemInitHash(const char *name, long init_size, long max_size, HASHCTL *infoP, int hash_flags,
                                     DiskquotaHashFunction hash_function);
 extern void  refresh_monitored_dbid_cache(void);

--- a/src/diskquota.h
+++ b/src/diskquota.h
@@ -77,6 +77,7 @@ extern int diskquota_worker_timeout;
 
 #define EXTENSION_DDL_MESSAGE_SIZE sizeof(ExtensionDDLMessage)
 #define ACTIVE_TABLES_MAP_ENTRY_SIZE sizeof(DiskQuotaActiveTableFileEntry)
+#define RELATION_CACHE_ENTRY_SIZE sizeof(DiskQuotaRelationCacheEntry)
 
 typedef enum
 {

--- a/src/diskquota.h
+++ b/src/diskquota.h
@@ -79,6 +79,7 @@ extern int diskquota_worker_timeout;
 #define ACTIVE_TABLES_MAP_ENTRY_SIZE sizeof(DiskQuotaActiveTableFileEntry)
 #define RELATION_CACHE_ENTRY_SIZE sizeof(DiskQuotaRelationCacheEntry)
 #define RELID_CACHE_ENTRY_SIZE sizeof(DiskQuotaRelidCacheEntry)
+#define ALTERED_RELOID_CACHE_ENTRY_SIZE sizeof(Oid)
 
 typedef enum
 {

--- a/src/diskquota.h
+++ b/src/diskquota.h
@@ -314,7 +314,6 @@ extern void         diskquota_stop_worker(void);
 extern void         update_monitordb_status(Oid dbid, uint32 status);
 extern HTAB        *diskquota_hash_create(const char *tabname, long nelem, HASHCTL *info, int flags,
                                           DiskquotaHashFunction hashFunction);
-extern void        *DiskquotaShmemInitStruct(const char *name, Size size, bool *foundPtr);
 extern HTAB *DiskquotaShmemInitHash(const char *name, long init_size, long max_size, HASHCTL *infoP, int hash_flags,
                                     DiskquotaHashFunction hash_function);
 extern void  refresh_monitored_dbid_cache(void);

--- a/src/diskquota.h
+++ b/src/diskquota.h
@@ -314,7 +314,7 @@ extern void         diskquota_stop_worker(void);
 extern void         update_monitordb_status(Oid dbid, uint32 status);
 extern HTAB        *diskquota_hash_create(const char *tabname, long nelem, HASHCTL *info, int flags,
                                           DiskquotaHashFunction hashFunction);
-extern void *DiskquotaShmemInitStruct(const char *name, Size size, bool *foundPtr);
+extern void        *DiskquotaShmemInitStruct(const char *name, Size size, bool *foundPtr);
 extern HTAB *DiskquotaShmemInitHash(const char *name, long init_size, long max_size, HASHCTL *infoP, int hash_flags,
                                     DiskquotaHashFunction hash_function);
 extern void  refresh_monitored_dbid_cache(void);

--- a/src/diskquota.h
+++ b/src/diskquota.h
@@ -323,6 +323,7 @@ extern HTAB        *diskquota_hash_create(const char *tabname, long nelem, HASHC
                                           DiskquotaHashFunction hashFunction);
 extern HTAB *DiskquotaShmemInitHash(const char *name, long init_size, long max_size, HASHCTL *infoP, int hash_flags,
                                     DiskquotaHashFunction hash_function);
+extern void *DiskquotaShmemInitStruct(const char *name, Size size, bool *foundPtr);
 extern void  refresh_monitored_dbid_cache(void);
 extern HASHACTION check_hash_fullness(HTAB *hashp, int max_size, const char *warning_message,
                                       TimestampTz *last_overflow_report);

--- a/src/diskquota.h
+++ b/src/diskquota.h
@@ -80,6 +80,7 @@ extern int diskquota_worker_timeout;
 #define RELATION_CACHE_ENTRY_SIZE sizeof(DiskQuotaRelationCacheEntry)
 #define RELID_CACHE_ENTRY_SIZE sizeof(DiskQuotaRelidCacheEntry)
 #define ALTERED_RELOID_CACHE_ENTRY_SIZE sizeof(Oid)
+#define MONITORED_DBID_CACHE_ENTRY_SIZE sizeof(struct MonitorDBEntryStruct)
 
 typedef enum
 {

--- a/src/diskquota.h
+++ b/src/diskquota.h
@@ -75,6 +75,8 @@ extern int diskquota_worker_timeout;
 #define DiskquotaGetRelstorage(classForm) (0)
 #endif /* GP_VERSION_NUM */
 
+#define EXTENSION_DDL_MESSAGE_SIZE sizeof(ExtensionDDLMessage)
+
 typedef enum
 {
 	NAMESPACE_QUOTA = 0,

--- a/src/diskquota.h
+++ b/src/diskquota.h
@@ -76,6 +76,7 @@ extern int diskquota_worker_timeout;
 #endif /* GP_VERSION_NUM */
 
 #define EXTENSION_DDL_MESSAGE_SIZE sizeof(ExtensionDDLMessage)
+#define ACTIVE_TABLES_MAP_ENTRY_SIZE sizeof(DiskQuotaActiveTableFileEntry)
 
 typedef enum
 {

--- a/src/diskquota_utility.c
+++ b/src/diskquota_utility.c
@@ -118,6 +118,8 @@ static void   check_role(Oid roleoid, char *rolname, int64 quota_limit_mb);
 extern DiskquotaLauncherShmemStruct *DiskquotaLauncherShmem;
 extern pg_atomic_uint64             *diskquota_shmem_size;
 extern void                          diskquota_shmem_size_sub(Size size);
+#else
+#define diskquota_shmem_size_sub(size) ((void)true)
 #endif
 
 /* ---- Help Functions to set quota limit. ---- */
@@ -1648,10 +1650,7 @@ DiskquotaShmemInitHash(const char           *name,       /* table string name fo
                        int                   hash_flags, /* info about infoP */
                        DiskquotaHashFunction hashFunction)
 {
-#ifdef USE_ASSERT_CHECKING
-	if (!DiskquotaLauncherShmem || !DiskquotaLauncherShmem->isDynamicWorker)
-		diskquota_shmem_size_sub(hash_estimate_size(max_size, infoP->entrysize));
-#endif
+	diskquota_shmem_size_sub(hash_estimate_size(max_size, infoP->entrysize));
 #if GP_VERSION_NUM < 70000
 	if (hashFunction == DISKQUOTA_TAG_HASH)
 		infoP->hash = tag_hash;

--- a/src/diskquota_utility.c
+++ b/src/diskquota_utility.c
@@ -1656,8 +1656,7 @@ DiskquotaShmemInitHash(const char           *name,       /* table string name fo
                        DiskquotaHashFunction hashFunction)
 {
 #ifdef USE_ASSERT_CHECKING
-	pg_atomic_sub_fetch_u64(diskquota_shmem_size,
-	                        hash_estimate_size(max_size, infoP->entrysize));
+	pg_atomic_sub_fetch_u64(diskquota_shmem_size, hash_estimate_size(max_size, infoP->entrysize));
 #endif
 #if GP_VERSION_NUM < 70000
 	if (hashFunction == DISKQUOTA_TAG_HASH)

--- a/src/diskquota_utility.c
+++ b/src/diskquota_utility.c
@@ -114,6 +114,10 @@ static float4 get_per_segment_ratio(Oid spcoid);
 static bool   to_delete_quota(QuotaType type, int64 quota_limit_mb, float4 segratio);
 static void   check_role(Oid roleoid, char *rolname, int64 quota_limit_mb);
 
+#ifdef USE_ASSERT_CHECKING
+extern pg_atomic_uint64 *diskquota_shmem_size;
+#endif
+
 /* ---- Help Functions to set quota limit. ---- */
 /*
  * Initialize table diskquota.table_size.
@@ -1634,6 +1638,15 @@ diskquota_hash_create(const char *tabname, long nelem, HASHCTL *info, int flags,
 #endif /* GP_VERSION_NUM */
 }
 
+void *
+DiskquotaShmemInitStruct(const char *name, Size size, bool *foundPtr)
+{
+#ifdef USE_ASSERT_CHECKING
+	pg_atomic_sub_fetch_u64(diskquota_shmem_size, size);
+#endif
+	return ShmemInitStruct(name, size, foundPtr);
+}
+
 HTAB *
 DiskquotaShmemInitHash(const char           *name,       /* table string name for shmem index */
                        long                  init_size,  /* initial table size */
@@ -1642,6 +1655,10 @@ DiskquotaShmemInitHash(const char           *name,       /* table string name fo
                        int                   hash_flags, /* info about infoP */
                        DiskquotaHashFunction hashFunction)
 {
+#ifdef USE_ASSERT_CHECKING
+	pg_atomic_sub_fetch_u64(diskquota_shmem_size,
+	                        hash_estimate_size(max_size, infoP->entrysize));
+#endif
 #if GP_VERSION_NUM < 70000
 	if (hashFunction == DISKQUOTA_TAG_HASH)
 		infoP->hash = tag_hash;

--- a/src/diskquota_utility.c
+++ b/src/diskquota_utility.c
@@ -1638,15 +1638,6 @@ diskquota_hash_create(const char *tabname, long nelem, HASHCTL *info, int flags,
 #endif /* GP_VERSION_NUM */
 }
 
-void *
-DiskquotaShmemInitStruct(const char *name, Size size, bool *foundPtr)
-{
-#ifdef USE_ASSERT_CHECKING
-	pg_atomic_sub_fetch_u64(diskquota_shmem_size, size);
-#endif
-	return ShmemInitStruct(name, size, foundPtr);
-}
-
 HTAB *
 DiskquotaShmemInitHash(const char           *name,       /* table string name for shmem index */
                        long                  init_size,  /* initial table size */

--- a/src/diskquota_utility.c
+++ b/src/diskquota_utility.c
@@ -114,6 +114,8 @@ static float4 get_per_segment_ratio(Oid spcoid);
 static bool   to_delete_quota(QuotaType type, int64 quota_limit_mb, float4 segratio);
 static void   check_role(Oid roleoid, char *rolname, int64 quota_limit_mb);
 
+extern DiskquotaLauncherShmemStruct *DiskquotaLauncherShmem;
+
 #ifdef USE_ASSERT_CHECKING
 extern pg_atomic_uint64 *diskquota_shmem_size;
 #endif
@@ -1647,7 +1649,8 @@ DiskquotaShmemInitHash(const char           *name,       /* table string name fo
                        DiskquotaHashFunction hashFunction)
 {
 #ifdef USE_ASSERT_CHECKING
-	pg_atomic_sub_fetch_u64(diskquota_shmem_size, hash_estimate_size(max_size, infoP->entrysize));
+	if (!DiskquotaLauncherShmem || !DiskquotaLauncherShmem->isDynamicWorker)
+		pg_atomic_sub_fetch_u64(diskquota_shmem_size, hash_estimate_size(max_size, infoP->entrysize));
 #endif
 #if GP_VERSION_NUM < 70000
 	if (hashFunction == DISKQUOTA_TAG_HASH)

--- a/src/diskquota_utility.c
+++ b/src/diskquota_utility.c
@@ -1649,7 +1649,11 @@ DiskquotaShmemInitHash(const char           *name,       /* table string name fo
 {
 #ifdef USE_ASSERT_CHECKING
 	if (!DiskquotaLauncherShmem || !DiskquotaLauncherShmem->isDynamicWorker)
-		pg_atomic_sub_fetch_u64(diskquota_shmem_size, hash_estimate_size(max_size, infoP->entrysize));
+	{
+		Size size = hash_estimate_size(max_size, infoP->entrysize);
+		Assert(pg_atomic_read_u64(diskquota_shmem_size) >= size);
+		pg_atomic_sub_fetch_u64(diskquota_shmem_size, size);
+	}
 #endif
 #if GP_VERSION_NUM < 70000
 	if (hashFunction == DISKQUOTA_TAG_HASH)

--- a/src/diskquota_utility.c
+++ b/src/diskquota_utility.c
@@ -1647,8 +1647,10 @@ DiskquotaShmemInitHash(const char           *name,       /* table string name fo
                        int                   hash_flags, /* info about infoP */
                        DiskquotaHashFunction hashFunction)
 {
+#ifdef USE_ASSERT_CHECKING
 	if (!DiskquotaLauncherShmem || !DiskquotaLauncherShmem->isDynamicWorker)
 		diskquota_shmem_size_sub(hash_estimate_size(max_size, infoP->entrysize));
+#endif
 
 #if GP_VERSION_NUM < 70000
 	if (hashFunction == DISKQUOTA_TAG_HASH)
@@ -1666,7 +1668,9 @@ DiskquotaShmemInitHash(const char           *name,       /* table string name fo
 void *
 DiskquotaShmemInitStruct(const char *name, Size size, bool *foundPtr)
 {
+#ifdef USE_ASSERT_CHECKING
 	if (!DiskquotaLauncherShmem || !DiskquotaLauncherShmem->isDynamicWorker) diskquota_shmem_size_sub(size);
+#endif
 
 	return ShmemInitStruct(name, size, foundPtr);
 }

--- a/src/diskquota_utility.c
+++ b/src/diskquota_utility.c
@@ -116,10 +116,7 @@ static void   check_role(Oid roleoid, char *rolname, int64 quota_limit_mb);
 
 #ifdef USE_ASSERT_CHECKING
 extern DiskquotaLauncherShmemStruct *DiskquotaLauncherShmem;
-extern pg_atomic_uint64             *diskquota_shmem_size;
 extern void                          diskquota_shmem_size_sub(Size size);
-#else
-#define diskquota_shmem_size_sub(size) ((void)true)
 #endif
 
 /* ---- Help Functions to set quota limit. ---- */
@@ -1650,7 +1647,9 @@ DiskquotaShmemInitHash(const char           *name,       /* table string name fo
                        int                   hash_flags, /* info about infoP */
                        DiskquotaHashFunction hashFunction)
 {
-	diskquota_shmem_size_sub(hash_estimate_size(max_size, infoP->entrysize));
+	if (!DiskquotaLauncherShmem || !DiskquotaLauncherShmem->isDynamicWorker)
+		diskquota_shmem_size_sub(hash_estimate_size(max_size, infoP->entrysize));
+
 #if GP_VERSION_NUM < 70000
 	if (hashFunction == DISKQUOTA_TAG_HASH)
 		infoP->hash = tag_hash;
@@ -1662,6 +1661,14 @@ DiskquotaShmemInitHash(const char           *name,       /* table string name fo
 #else
 	return ShmemInitHash(name, init_size, max_size, infoP, hash_flags | HASH_BLOBS);
 #endif /* GP_VERSION_NUM */
+}
+
+void *
+DiskquotaShmemInitStruct(const char *name, Size size, bool *foundPtr)
+{
+	if (!DiskquotaLauncherShmem || !DiskquotaLauncherShmem->isDynamicWorker) diskquota_shmem_size_sub(size);
+
+	return ShmemInitStruct(name, size, foundPtr);
 }
 
 /*

--- a/src/diskquota_utility.c
+++ b/src/diskquota_utility.c
@@ -117,6 +117,7 @@ static void   check_role(Oid roleoid, char *rolname, int64 quota_limit_mb);
 #ifdef USE_ASSERT_CHECKING
 extern DiskquotaLauncherShmemStruct *DiskquotaLauncherShmem;
 extern pg_atomic_uint64             *diskquota_shmem_size;
+extern void                          diskquota_shmem_size_sub(Size size);
 #endif
 
 /* ---- Help Functions to set quota limit. ---- */
@@ -1649,11 +1650,7 @@ DiskquotaShmemInitHash(const char           *name,       /* table string name fo
 {
 #ifdef USE_ASSERT_CHECKING
 	if (!DiskquotaLauncherShmem || !DiskquotaLauncherShmem->isDynamicWorker)
-	{
-		Size size = hash_estimate_size(max_size, infoP->entrysize);
-		Assert(pg_atomic_read_u64(diskquota_shmem_size) >= size);
-		pg_atomic_sub_fetch_u64(diskquota_shmem_size, size);
-	}
+		diskquota_shmem_size_sub(hash_estimate_size(max_size, infoP->entrysize));
 #endif
 #if GP_VERSION_NUM < 70000
 	if (hashFunction == DISKQUOTA_TAG_HASH)

--- a/src/diskquota_utility.c
+++ b/src/diskquota_utility.c
@@ -114,10 +114,9 @@ static float4 get_per_segment_ratio(Oid spcoid);
 static bool   to_delete_quota(QuotaType type, int64 quota_limit_mb, float4 segratio);
 static void   check_role(Oid roleoid, char *rolname, int64 quota_limit_mb);
 
-extern DiskquotaLauncherShmemStruct *DiskquotaLauncherShmem;
-
 #ifdef USE_ASSERT_CHECKING
-extern pg_atomic_uint64 *diskquota_shmem_size;
+extern DiskquotaLauncherShmemStruct *DiskquotaLauncherShmem;
+extern pg_atomic_uint64             *diskquota_shmem_size;
 #endif
 
 /* ---- Help Functions to set quota limit. ---- */

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -109,8 +109,8 @@ init_shm_worker_active_tables(void)
 	HASHCTL ctl;
 
 	memset(&ctl, 0, sizeof(ctl));
-	ctl.keysize       = sizeof(DiskQuotaActiveTableFileEntry);
-	ctl.entrysize     = sizeof(DiskQuotaActiveTableFileEntry);
+	ctl.keysize       = ACTIVE_TABLES_MAP_ENTRY_SIZE;
+	ctl.entrysize     = ACTIVE_TABLES_MAP_ENTRY_SIZE;
 	active_tables_map = DiskquotaShmemInitHash("active_tables", diskquota_max_active_tables,
 	                                           diskquota_max_active_tables, &ctl, HASH_ELEM, DISKQUOTA_TAG_HASH);
 
@@ -322,7 +322,7 @@ report_active_table_helper(const RelFileNodeBackend *relFileNode)
 	}
 	found = false;
 
-	MemSet(&item, 0, sizeof(DiskQuotaActiveTableFileEntry));
+	MemSet(&item, 0, ACTIVE_TABLES_MAP_ENTRY_SIZE);
 	item.dbid          = relFileNode->node.dbNode;
 	item.relfilenode   = relFileNode->node.relNode;
 	item.tablespaceoid = relFileNode->node.spcNode;
@@ -730,8 +730,8 @@ get_active_tables_oid(void)
 	refresh_monitored_dbid_cache();
 
 	memset(&ctl, 0, sizeof(ctl));
-	ctl.keysize                 = sizeof(DiskQuotaActiveTableFileEntry);
-	ctl.entrysize               = sizeof(DiskQuotaActiveTableFileEntry);
+	ctl.keysize                 = ACTIVE_TABLES_MAP_ENTRY_SIZE;
+	ctl.entrysize               = ACTIVE_TABLES_MAP_ENTRY_SIZE;
 	ctl.hcxt                    = CurrentMemoryContext;
 	local_active_table_file_map = diskquota_hash_create("local active table map with relfilenode info", 1024, &ctl,
 	                                                    HASH_ELEM | HASH_CONTEXT, DISKQUOTA_TAG_HASH);

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -79,6 +79,10 @@ static file_truncate_hook_type prev_file_truncate_hook = NULL;
 static file_unlink_hook_type   prev_file_unlink_hook   = NULL;
 static object_access_hook_type prev_object_access_hook = NULL;
 
+#ifdef USE_ASSERT_CHECKING
+extern pg_atomic_uint32 *diskquota_shmem_size;
+#endif
+
 static void active_table_hook_smgrcreate(RelFileNodeBackend rnode);
 static void active_table_hook_smgrextend(RelFileNodeBackend rnode);
 static void active_table_hook_smgrtruncate(RelFileNodeBackend rnode);
@@ -114,11 +118,19 @@ init_shm_worker_active_tables(void)
 	active_tables_map = DiskquotaShmemInitHash("active_tables", diskquota_max_active_tables,
 	                                           diskquota_max_active_tables, &ctl, HASH_ELEM, DISKQUOTA_TAG_HASH);
 
+#ifdef USE_ASSERT_CHECKING
+	pg_atomic_sub_fetch_u32(diskquota_shmem_size, hash_estimate_size(diskquota_max_active_tables, sizeof(DiskQuotaActiveTableFileEntry)));
+#endif
+
 	memset(&ctl, 0, sizeof(ctl));
 	ctl.keysize          = sizeof(Oid);
 	ctl.entrysize        = sizeof(Oid);
 	altered_reloid_cache = DiskquotaShmemInitHash("altered_reloid_cache", diskquota_max_active_tables,
 	                                              diskquota_max_active_tables, &ctl, HASH_ELEM, DISKQUOTA_OID_HASH);
+
+#ifdef USE_ASSERT_CHECKING
+	pg_atomic_sub_fetch_u32(diskquota_shmem_size, hash_estimate_size(diskquota_max_active_tables, sizeof(Oid)));
+#endif
 }
 
 /*

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -80,7 +80,7 @@ static file_unlink_hook_type   prev_file_unlink_hook   = NULL;
 static object_access_hook_type prev_object_access_hook = NULL;
 
 #ifdef USE_ASSERT_CHECKING
-extern pg_atomic_uint32 *diskquota_shmem_size;
+extern pg_atomic_uint64 *diskquota_shmem_size;
 #endif
 
 static void active_table_hook_smgrcreate(RelFileNodeBackend rnode);
@@ -119,7 +119,7 @@ init_shm_worker_active_tables(void)
 	                                           diskquota_max_active_tables, &ctl, HASH_ELEM, DISKQUOTA_TAG_HASH);
 
 #ifdef USE_ASSERT_CHECKING
-	pg_atomic_sub_fetch_u32(diskquota_shmem_size,
+	pg_atomic_sub_fetch_u64(diskquota_shmem_size,
 	                        hash_estimate_size(diskquota_max_active_tables, sizeof(DiskQuotaActiveTableFileEntry)));
 #endif
 
@@ -130,7 +130,7 @@ init_shm_worker_active_tables(void)
 	                                              diskquota_max_active_tables, &ctl, HASH_ELEM, DISKQUOTA_OID_HASH);
 
 #ifdef USE_ASSERT_CHECKING
-	pg_atomic_sub_fetch_u32(diskquota_shmem_size, hash_estimate_size(diskquota_max_active_tables, sizeof(Oid)));
+	pg_atomic_sub_fetch_u64(diskquota_shmem_size, hash_estimate_size(diskquota_max_active_tables, sizeof(Oid)));
 #endif
 }
 

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -115,8 +115,8 @@ init_shm_worker_active_tables(void)
 	                                           diskquota_max_active_tables, &ctl, HASH_ELEM, DISKQUOTA_TAG_HASH);
 
 	memset(&ctl, 0, sizeof(ctl));
-	ctl.keysize          = sizeof(Oid);
-	ctl.entrysize        = sizeof(Oid);
+	ctl.keysize          = ALTERED_RELOID_CACHE_ENTRY_SIZE;
+	ctl.entrysize        = ALTERED_RELOID_CACHE_ENTRY_SIZE;
 	altered_reloid_cache = DiskquotaShmemInitHash("altered_reloid_cache", diskquota_max_active_tables,
 	                                              diskquota_max_active_tables, &ctl, HASH_ELEM, DISKQUOTA_OID_HASH);
 }
@@ -737,8 +737,8 @@ get_active_tables_oid(void)
 	                                                    HASH_ELEM | HASH_CONTEXT, DISKQUOTA_TAG_HASH);
 
 	memset(&ctl, 0, sizeof(ctl));
-	ctl.keysize                = sizeof(Oid);
-	ctl.entrysize              = sizeof(Oid);
+	ctl.keysize                = ALTERED_RELOID_CACHE_ENTRY_SIZE;
+	ctl.entrysize              = ALTERED_RELOID_CACHE_ENTRY_SIZE;
 	ctl.hcxt                   = CurrentMemoryContext;
 	local_altered_reloid_cache = diskquota_hash_create("local_altered_reloid_cache", 1024, &ctl,
 	                                                   HASH_ELEM | HASH_CONTEXT, DISKQUOTA_OID_HASH);

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -119,7 +119,8 @@ init_shm_worker_active_tables(void)
 	                                           diskquota_max_active_tables, &ctl, HASH_ELEM, DISKQUOTA_TAG_HASH);
 
 #ifdef USE_ASSERT_CHECKING
-	pg_atomic_sub_fetch_u32(diskquota_shmem_size, hash_estimate_size(diskquota_max_active_tables, sizeof(DiskQuotaActiveTableFileEntry)));
+	pg_atomic_sub_fetch_u32(diskquota_shmem_size,
+	                        hash_estimate_size(diskquota_max_active_tables, sizeof(DiskQuotaActiveTableFileEntry)));
 #endif
 
 	memset(&ctl, 0, sizeof(ctl));

--- a/src/gp_activetable.c
+++ b/src/gp_activetable.c
@@ -79,10 +79,6 @@ static file_truncate_hook_type prev_file_truncate_hook = NULL;
 static file_unlink_hook_type   prev_file_unlink_hook   = NULL;
 static object_access_hook_type prev_object_access_hook = NULL;
 
-#ifdef USE_ASSERT_CHECKING
-extern pg_atomic_uint64 *diskquota_shmem_size;
-#endif
-
 static void active_table_hook_smgrcreate(RelFileNodeBackend rnode);
 static void active_table_hook_smgrextend(RelFileNodeBackend rnode);
 static void active_table_hook_smgrtruncate(RelFileNodeBackend rnode);
@@ -118,20 +114,11 @@ init_shm_worker_active_tables(void)
 	active_tables_map = DiskquotaShmemInitHash("active_tables", diskquota_max_active_tables,
 	                                           diskquota_max_active_tables, &ctl, HASH_ELEM, DISKQUOTA_TAG_HASH);
 
-#ifdef USE_ASSERT_CHECKING
-	pg_atomic_sub_fetch_u64(diskquota_shmem_size,
-	                        hash_estimate_size(diskquota_max_active_tables, sizeof(DiskQuotaActiveTableFileEntry)));
-#endif
-
 	memset(&ctl, 0, sizeof(ctl));
 	ctl.keysize          = sizeof(Oid);
 	ctl.entrysize        = sizeof(Oid);
 	altered_reloid_cache = DiskquotaShmemInitHash("altered_reloid_cache", diskquota_max_active_tables,
 	                                              diskquota_max_active_tables, &ctl, HASH_ELEM, DISKQUOTA_OID_HASH);
-
-#ifdef USE_ASSERT_CHECKING
-	pg_atomic_sub_fetch_u64(diskquota_shmem_size, hash_estimate_size(diskquota_max_active_tables, sizeof(Oid)));
-#endif
 }
 
 /*

--- a/src/monitored_db.c
+++ b/src/monitored_db.c
@@ -322,14 +322,14 @@ dump_monitored_dbid_cache(long *nitems)
 	HASH_SEQ_STATUS seq;
 	MonitorDBEntry  curEntry;
 	int             count = *nitems = hash_get_num_entries(monitored_dbid_cache);
-	MonitorDBEntry  entries = curEntry = (MonitorDBEntry)palloc(sizeof(struct MonitorDBEntryStruct) * count);
+	MonitorDBEntry  entries = curEntry = (MonitorDBEntry)palloc(MONITORED_DBID_CACHE_ENTRY_SIZE * count);
 
 	hash_seq_init(&seq, monitored_dbid_cache);
 	MonitorDBEntry entry;
 	while ((entry = hash_seq_search(&seq)) != NULL)
 	{
 		Assert(count > 0);
-		memcpy(curEntry, entry, sizeof(struct MonitorDBEntryStruct));
+		memcpy(curEntry, entry, MONITORED_DBID_CACHE_ENTRY_SIZE);
 		curEntry++;
 		count--;
 	}

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -488,7 +488,6 @@ disk_quota_shmem_startup(void)
 	monitored_dbid_cache =
 	        DiskquotaShmemInitHash("table oid cache which shoud tracking", diskquota_max_monitored_databases,
 	                               diskquota_max_monitored_databases, &hash_ctl, HASH_ELEM, DISKQUOTA_OID_HASH);
-
 	if (IS_QUERY_DISPATCHER()) init_launcher_shmem();
 	LWLockRelease(AddinShmemInitLock);
 

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -76,6 +76,7 @@
 #define QUOTA_INFO_MAP_LAST_OVERFLOW_REPORT_SIZE sizeof(TimestampTz)
 #define DISK_QUOTA_REJECT_MAP_ENTRY_SIZE sizeof(GlobalRejectMapEntry)
 #define TABLE_SIZE_MAP_ENTRY_SIZE sizeof(TableSizeEntry)
+#define LOCAL_DISK_QUOTA_REJECT_MAP_ENTRY_SIZE sizeof(LocalRejectMapEntry)
 
 typedef struct TableSizeEntry       TableSizeEntry;
 typedef struct NamespaceSizeEntry   NamespaceSizeEntry;
@@ -549,8 +550,8 @@ diskquota_worker_shmem_size(void)
 {
 	Size size;
 	size = hash_estimate_size(MAX_NUM_TABLE_SIZE_ENTRIES, TABLE_SIZE_MAP_ENTRY_SIZE);
-	size = add_size(size, hash_estimate_size(diskquota_max_local_reject_entries,
-	                                         sizeof(LocalRejectMapEntry))); // local_disk_quota_reject_map
+	size = add_size(size,
+	                hash_estimate_size(diskquota_max_local_reject_entries, LOCAL_DISK_QUOTA_REJECT_MAP_ENTRY_SIZE));
 	size = add_size(size, hash_estimate_size(MAX_QUOTA_MAP_ENTRIES, sizeof(QuotaInfoEntry))); // quota_info_map
 	size = add_size(size, TABLE_SIZE_MAP_LAST_OVERFLOW_REPORT_SIZE);
 	size = add_size(size, LOCAL_DISK_QUOTA_REJECT_MAP_LAST_OVERFLOW_REPORT_SIZE);
@@ -619,7 +620,7 @@ init_disk_quota_model(uint32 id)
 	format_name("localrejectmap", id, &str);
 	memset(&hash_ctl, 0, sizeof(hash_ctl));
 	hash_ctl.keysize   = sizeof(RejectMapEntry);
-	hash_ctl.entrysize = sizeof(LocalRejectMapEntry);
+	hash_ctl.entrysize = LOCAL_DISK_QUOTA_REJECT_MAP_ENTRY_SIZE;
 	local_disk_quota_reject_map =
 	        DiskquotaShmemInitHash(str.data, diskquota_max_local_reject_entries, diskquota_max_local_reject_entries,
 	                               &hash_ctl, HASH_ELEM, DISKQUOTA_TAG_HASH);
@@ -696,7 +697,7 @@ vacuum_disk_quota_model(uint32 id)
 	format_name("localrejectmap", id, &str);
 	memset(&hash_ctl, 0, sizeof(hash_ctl));
 	hash_ctl.keysize   = sizeof(RejectMapEntry);
-	hash_ctl.entrysize = sizeof(LocalRejectMapEntry);
+	hash_ctl.entrysize = LOCAL_DISK_QUOTA_REJECT_MAP_ENTRY_SIZE;
 	local_disk_quota_reject_map =
 	        DiskquotaShmemInitHash(str.data, diskquota_max_local_reject_entries, diskquota_max_local_reject_entries,
 	                               &hash_ctl, HASH_ELEM, DISKQUOTA_TAG_HASH);

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -75,6 +75,7 @@
 #define LOCAL_DISK_QUOTA_REJECT_MAP_LAST_OVERFLOW_REPORT_SIZE sizeof(TimestampTz)
 #define QUOTA_INFO_MAP_LAST_OVERFLOW_REPORT_SIZE sizeof(TimestampTz)
 #define DISK_QUOTA_REJECT_MAP_ENTRY_SIZE sizeof(GlobalRejectMapEntry)
+#define TABLE_SIZE_MAP_ENTRY_SIZE sizeof(TableSizeEntry)
 
 typedef struct TableSizeEntry       TableSizeEntry;
 typedef struct NamespaceSizeEntry   NamespaceSizeEntry;
@@ -547,7 +548,7 @@ static Size
 diskquota_worker_shmem_size(void)
 {
 	Size size;
-	size = hash_estimate_size(MAX_NUM_TABLE_SIZE_ENTRIES, sizeof(TableSizeEntry)); // table_size_map
+	size = hash_estimate_size(MAX_NUM_TABLE_SIZE_ENTRIES, TABLE_SIZE_MAP_ENTRY_SIZE);
 	size = add_size(size, hash_estimate_size(diskquota_max_local_reject_entries,
 	                                         sizeof(LocalRejectMapEntry))); // local_disk_quota_reject_map
 	size = add_size(size, hash_estimate_size(MAX_QUOTA_MAP_ENTRIES, sizeof(QuotaInfoEntry))); // quota_info_map
@@ -602,7 +603,7 @@ init_disk_quota_model(uint32 id)
 	format_name("TableSizeEntrymap", id, &str);
 	memset(&hash_ctl, 0, sizeof(hash_ctl));
 	hash_ctl.keysize   = sizeof(TableSizeEntryKey);
-	hash_ctl.entrysize = sizeof(TableSizeEntry);
+	hash_ctl.entrysize = TABLE_SIZE_MAP_ENTRY_SIZE;
 	table_size_map     = DiskquotaShmemInitHash(str.data, INIT_NUM_TABLE_SIZE_ENTRIES, MAX_NUM_TABLE_SIZE_ENTRIES,
 	                                            &hash_ctl, HASH_ELEM, DISKQUOTA_TAG_HASH);
 	format_name("TableSizeEntrymap_last_overflow_report", id, &str);
@@ -679,7 +680,7 @@ vacuum_disk_quota_model(uint32 id)
 	format_name("TableSizeEntrymap", id, &str);
 	memset(&hash_ctl, 0, sizeof(hash_ctl));
 	hash_ctl.keysize   = sizeof(TableSizeEntryKey);
-	hash_ctl.entrysize = sizeof(TableSizeEntry);
+	hash_ctl.entrysize = TABLE_SIZE_MAP_ENTRY_SIZE;
 	table_size_map     = DiskquotaShmemInitHash(str.data, INIT_NUM_TABLE_SIZE_ENTRIES, MAX_NUM_TABLE_SIZE_ENTRIES,
 	                                            &hash_ctl, HASH_ELEM, DISKQUOTA_TAG_HASH);
 	hash_seq_init(&iter, table_size_map);

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -610,8 +610,6 @@ init_disk_quota_model(uint32 id)
 	Assert(pg_atomic_read_u32(diskquota_shmem_size) >= 0);
 #endif
 
-	LWLockAcquire(AddinShmemInitLock, LW_EXCLUSIVE);
-
 	format_name("TableSizeEntrymap", id, &str);
 	memset(&hash_ctl, 0, sizeof(hash_ctl));
 	hash_ctl.keysize   = sizeof(TableSizeEntryKey);
@@ -676,8 +674,6 @@ init_disk_quota_model(uint32 id)
 #endif
 
 	pfree(str.data);
-
-	LWLockRelease(AddinShmemInitLock);
 
 #ifdef USE_ASSERT_CHECKING
 	Assert(pg_atomic_read_u32(diskquota_shmem_size) >= 0);

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -222,6 +222,8 @@ static shmem_startup_hook_type prev_shmem_startup_hook = NULL;
 extern DiskquotaLauncherShmemStruct *DiskquotaLauncherShmem;
 pg_atomic_uint64                    *diskquota_shmem_size;
 void                                 diskquota_shmem_size_sub(Size size);
+#else
+#define diskquota_shmem_size_sub(size) ((void)true)
 #endif
 
 /* functions to maintain the quota maps */
@@ -612,11 +614,7 @@ init_disk_quota_model(uint32 id)
 	format_name("TableSizeEntrymap_last_overflow_report", id, &str);
 	table_size_map_last_overflow_report = ShmemInitStruct(str.data, TABLE_SIZE_MAP_LAST_OVERFLOW_REPORT_SIZE, &found);
 	if (!found) *table_size_map_last_overflow_report = 0;
-
-#ifdef USE_ASSERT_CHECKING
-	if (!DiskquotaLauncherShmem || !DiskquotaLauncherShmem->isDynamicWorker)
-		diskquota_shmem_size_sub(TABLE_SIZE_MAP_LAST_OVERFLOW_REPORT_SIZE);
-#endif
+	diskquota_shmem_size_sub(TABLE_SIZE_MAP_LAST_OVERFLOW_REPORT_SIZE);
 
 	/* for localrejectmap */
 	/* WARNNING: The max length of name of the map is 48 */
@@ -632,11 +630,7 @@ init_disk_quota_model(uint32 id)
 	local_disk_quota_reject_map_last_overflow_report =
 	        ShmemInitStruct(str.data, LOCAL_DISK_QUOTA_REJECT_MAP_LAST_OVERFLOW_REPORT_SIZE, &found);
 	if (!found) *local_disk_quota_reject_map_last_overflow_report = 0;
-
-#ifdef USE_ASSERT_CHECKING
-	if (!DiskquotaLauncherShmem || !DiskquotaLauncherShmem->isDynamicWorker)
-		diskquota_shmem_size_sub(LOCAL_DISK_QUOTA_REJECT_MAP_LAST_OVERFLOW_REPORT_SIZE);
-#endif
+	diskquota_shmem_size_sub(LOCAL_DISK_QUOTA_REJECT_MAP_LAST_OVERFLOW_REPORT_SIZE);
 
 	/* for quota_info_map */
 	format_name("QuotaInfoMap", id, &str);
@@ -648,11 +642,7 @@ init_disk_quota_model(uint32 id)
 	format_name("QuotaInfoMap_last_overflow_report", id, &str);
 	quota_info_map_last_overflow_report = ShmemInitStruct(str.data, QUOTA_INFO_MAP_LAST_OVERFLOW_REPORT_SIZE, &found);
 	if (!found) *quota_info_map_last_overflow_report = 0;
-
-#ifdef USE_ASSERT_CHECKING
-	if (!DiskquotaLauncherShmem || !DiskquotaLauncherShmem->isDynamicWorker)
-		diskquota_shmem_size_sub(QUOTA_INFO_MAP_LAST_OVERFLOW_REPORT_SIZE);
-#endif
+	diskquota_shmem_size_sub(QUOTA_INFO_MAP_LAST_OVERFLOW_REPORT_SIZE);
 
 	pfree(str.data);
 }
@@ -698,11 +688,7 @@ vacuum_disk_quota_model(uint32 id)
 	format_name("TableSizeEntrymap_last_overflow_report", id, &str);
 	table_size_map_last_overflow_report = ShmemInitStruct(str.data, TABLE_SIZE_MAP_LAST_OVERFLOW_REPORT_SIZE, &found);
 	if (!found) *table_size_map_last_overflow_report = 0;
-
-#ifdef USE_ASSERT_CHECKING
-	if (!DiskquotaLauncherShmem || !DiskquotaLauncherShmem->isDynamicWorker)
-		diskquota_shmem_size_sub(TABLE_SIZE_MAP_LAST_OVERFLOW_REPORT_SIZE);
-#endif
+	diskquota_shmem_size_sub(TABLE_SIZE_MAP_LAST_OVERFLOW_REPORT_SIZE);
 
 	/* localrejectmap */
 	format_name("localrejectmap", id, &str);
@@ -721,11 +707,7 @@ vacuum_disk_quota_model(uint32 id)
 	local_disk_quota_reject_map_last_overflow_report =
 	        ShmemInitStruct(str.data, LOCAL_DISK_QUOTA_REJECT_MAP_LAST_OVERFLOW_REPORT_SIZE, &found);
 	if (!found) *local_disk_quota_reject_map_last_overflow_report = 0;
-
-#ifdef USE_ASSERT_CHECKING
-	if (!DiskquotaLauncherShmem || !DiskquotaLauncherShmem->isDynamicWorker)
-		diskquota_shmem_size_sub(LOCAL_DISK_QUOTA_REJECT_MAP_LAST_OVERFLOW_REPORT_SIZE);
-#endif
+	diskquota_shmem_size_sub(LOCAL_DISK_QUOTA_REJECT_MAP_LAST_OVERFLOW_REPORT_SIZE);
 
 	/* quota_info_map */
 	format_name("QuotaInfoMap", id, &str);
@@ -742,11 +724,7 @@ vacuum_disk_quota_model(uint32 id)
 	format_name("QuotaInfoMap_last_overflow_report", id, &str);
 	quota_info_map_last_overflow_report = ShmemInitStruct(str.data, QUOTA_INFO_MAP_LAST_OVERFLOW_REPORT_SIZE, &found);
 	if (!found) *quota_info_map_last_overflow_report = 0;
-
-#ifdef USE_ASSERT_CHECKING
-	if (!DiskquotaLauncherShmem || !DiskquotaLauncherShmem->isDynamicWorker)
-		diskquota_shmem_size_sub(QUOTA_INFO_MAP_LAST_OVERFLOW_REPORT_SIZE);
-#endif
+	diskquota_shmem_size_sub(QUOTA_INFO_MAP_LAST_OVERFLOW_REPORT_SIZE);
 
 	pfree(str.data);
 }
@@ -2440,6 +2418,8 @@ void
 diskquota_shmem_size_sub(Size size)
 {
 	Assert(pg_atomic_read_u64(diskquota_shmem_size) >= size);
-	pg_atomic_sub_fetch_u64(diskquota_shmem_size, size);
+
+	if (!DiskquotaLauncherShmem || !DiskquotaLauncherShmem->isDynamicWorker)
+		pg_atomic_sub_fetch_u64(diskquota_shmem_size, size);
 }
 #endif

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -573,8 +573,7 @@ DiskQuotaShmemSize(void)
 
 	size = add_size(size, hash_estimate_size(MAX_DISK_QUOTA_REJECT_ENTRIES, DISK_QUOTA_REJECT_MAP_ENTRY_SIZE));
 	size = add_size(size, hash_estimate_size(diskquota_max_active_tables, ACTIVE_TABLES_MAP_ENTRY_SIZE));
-	size = add_size(size, hash_estimate_size(diskquota_max_active_tables,
-	                                         sizeof(DiskQuotaRelationCacheEntry))); // relation_cache
+	size = add_size(size, hash_estimate_size(diskquota_max_active_tables, RELATION_CACHE_ENTRY_SIZE));
 	size = add_size(size,
 	                hash_estimate_size(diskquota_max_active_tables, sizeof(DiskQuotaRelidCacheEntry))); // relid_cache
 	size = add_size(size, hash_estimate_size(diskquota_max_active_tables, sizeof(Oid))); // altered_reloid_cache

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -210,6 +210,8 @@ static const char *local_disk_quota_reject_map_warning =
 
 static shmem_startup_hook_type prev_shmem_startup_hook = NULL;
 
+extern DiskquotaLauncherShmemStruct *DiskquotaLauncherShmem;
+
 #ifdef USE_ASSERT_CHECKING
 pg_atomic_uint64 *diskquota_shmem_size;
 #endif
@@ -599,7 +601,9 @@ init_disk_quota_model(uint32 id)
 	initStringInfo(&str);
 
 #ifdef USE_ASSERT_CHECKING
-	Assert(pg_atomic_read_u64(diskquota_shmem_size) >= 0);
+	Assert(DiskquotaLauncherShmem);
+
+	if (!DiskquotaLauncherShmem->isDynamicWorker) Assert(pg_atomic_read_u64(diskquota_shmem_size) >= 0);
 #endif
 
 	format_name("TableSizeEntrymap", id, &str);
@@ -650,7 +654,7 @@ init_disk_quota_model(uint32 id)
 	pfree(str.data);
 
 #ifdef USE_ASSERT_CHECKING
-	Assert(pg_atomic_read_u64(diskquota_shmem_size) >= 0);
+	if (!DiskquotaLauncherShmem->isDynamicWorker) Assert(pg_atomic_read_u64(diskquota_shmem_size) >= 0);
 #endif
 }
 

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -74,6 +74,7 @@
 #define TABLE_SIZE_MAP_LAST_OVERFLOW_REPORT_SIZE sizeof(TimestampTz)
 #define LOCAL_DISK_QUOTA_REJECT_MAP_LAST_OVERFLOW_REPORT_SIZE sizeof(TimestampTz)
 #define QUOTA_INFO_MAP_LAST_OVERFLOW_REPORT_SIZE sizeof(TimestampTz)
+#define DISK_QUOTA_REJECT_MAP_ENTRY_SIZE sizeof(GlobalRejectMapEntry)
 
 typedef struct TableSizeEntry       TableSizeEntry;
 typedef struct NamespaceSizeEntry   NamespaceSizeEntry;
@@ -477,7 +478,7 @@ disk_quota_shmem_startup(void)
 
 	memset(&hash_ctl, 0, sizeof(hash_ctl));
 	hash_ctl.keysize   = sizeof(RejectMapEntry);
-	hash_ctl.entrysize = sizeof(GlobalRejectMapEntry);
+	hash_ctl.entrysize = DISK_QUOTA_REJECT_MAP_ENTRY_SIZE;
 	disk_quota_reject_map =
 	        DiskquotaShmemInitHash("rejectmap whose quota limitation is reached", diskquota_max_local_reject_entries,
 	                               MAX_DISK_QUOTA_REJECT_ENTRIES, &hash_ctl, HASH_ELEM, DISKQUOTA_TAG_HASH);
@@ -570,8 +571,7 @@ DiskQuotaShmemSize(void)
 	size = add_size(size, sizeof(pg_atomic_uint64)); // diskquota_shmem_size
 #endif
 
-	size = add_size(size, hash_estimate_size(MAX_DISK_QUOTA_REJECT_ENTRIES,
-	                                         sizeof(GlobalRejectMapEntry))); // disk_quota_reject_map
+	size = add_size(size, hash_estimate_size(MAX_DISK_QUOTA_REJECT_ENTRIES, DISK_QUOTA_REJECT_MAP_ENTRY_SIZE));
 	size = add_size(size, hash_estimate_size(diskquota_max_active_tables,
 	                                         sizeof(DiskQuotaActiveTableFileEntry))); // active_tables_map
 	size = add_size(size, hash_estimate_size(diskquota_max_active_tables,
@@ -1973,7 +1973,7 @@ refresh_rejectmap(PG_FUNCTION_ARGS)
 	 */
 	memset(&hashctl, 0, sizeof(hashctl));
 	hashctl.keysize   = sizeof(RejectMapEntry);
-	hashctl.entrysize = sizeof(GlobalRejectMapEntry);
+	hashctl.entrysize = DISK_QUOTA_REJECT_MAP_ENTRY_SIZE;
 	hashctl.hcxt      = CurrentMemoryContext;
 
 	/*
@@ -2223,7 +2223,7 @@ refresh_rejectmap(PG_FUNCTION_ARGS)
 		        check_hash_fullness(disk_quota_reject_map, MAX_DISK_QUOTA_REJECT_ENTRIES, disk_quota_reject_map_warning,
 		                            &disk_quota_reject_map_last_overflow_report);
 		new_entry = hash_search(disk_quota_reject_map, &rejectmapentry->keyitem, action, &found);
-		if (!found && new_entry) memcpy(new_entry, rejectmapentry, sizeof(GlobalRejectMapEntry));
+		if (!found && new_entry) memcpy(new_entry, rejectmapentry, DISK_QUOTA_REJECT_MAP_ENTRY_SIZE);
 	}
 	LWLockRelease(diskquota_locks.reject_map_lock);
 
@@ -2277,7 +2277,7 @@ show_rejectmap(PG_FUNCTION_ARGS)
 		/* Create a local hash table and fill it with entries from shared memory. */
 		memset(&hashctl, 0, sizeof(hashctl));
 		hashctl.keysize          = sizeof(RejectMapEntry);
-		hashctl.entrysize        = sizeof(GlobalRejectMapEntry);
+		hashctl.entrysize        = DISK_QUOTA_REJECT_MAP_ENTRY_SIZE;
 		hashctl.hcxt             = CurrentMemoryContext;
 		rejectmap_ctx->rejectmap = diskquota_hash_create("rejectmap_ctx rejectmap", 1024, &hashctl,
 		                                                 HASH_ELEM | HASH_CONTEXT, DISKQUOTA_TAG_HASH);

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -608,7 +608,6 @@ init_disk_quota_model(uint32 id)
 	hash_ctl.entrysize = sizeof(TableSizeEntry);
 	table_size_map     = DiskquotaShmemInitHash(str.data, INIT_NUM_TABLE_SIZE_ENTRIES, MAX_NUM_TABLE_SIZE_ENTRIES,
 	                                            &hash_ctl, HASH_ELEM, DISKQUOTA_TAG_HASH);
-
 	format_name("TableSizeEntrymap_last_overflow_report", id, &str);
 	table_size_map_last_overflow_report = ShmemInitStruct(str.data, sizeof(TimestampTz), &found);
 	if (!found) *table_size_map_last_overflow_report = 0;
@@ -634,7 +633,6 @@ init_disk_quota_model(uint32 id)
 	hash_ctl.keysize   = sizeof(QuotaInfoEntryKey);
 	quota_info_map     = DiskquotaShmemInitHash(str.data, INIT_QUOTA_MAP_ENTRIES, MAX_QUOTA_MAP_ENTRIES, &hash_ctl,
 	                                            HASH_ELEM, DISKQUOTA_TAG_HASH);
-
 	format_name("QuotaInfoMap_last_overflow_report", id, &str);
 	quota_info_map_last_overflow_report = ShmemInitStruct(str.data, sizeof(TimestampTz), &found);
 	if (!found) *quota_info_map_last_overflow_report = 0;

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -450,8 +450,7 @@ disk_quota_shmem_startup(void)
 	LWLockAcquire(AddinShmemInitLock, LW_EXCLUSIVE);
 
 #ifdef USE_ASSERT_CHECKING
-	diskquota_shmem_size =
-	        ShmemInitStruct("diskquota_shmem_size", sizeof(pg_atomic_uint32), &found);
+	diskquota_shmem_size = ShmemInitStruct("diskquota_shmem_size", sizeof(pg_atomic_uint32), &found);
 	if (!found) pg_atomic_init_u32(diskquota_shmem_size, DiskQuotaShmemSize());
 	if (found) elog(WARNING, "diskquota_shmem_size found!");
 #endif
@@ -480,7 +479,8 @@ disk_quota_shmem_startup(void)
 	                               MAX_DISK_QUOTA_REJECT_ENTRIES, &hash_ctl, HASH_ELEM, DISKQUOTA_TAG_HASH);
 
 #ifdef USE_ASSERT_CHECKING
-	pg_atomic_sub_fetch_u32(diskquota_shmem_size, hash_estimate_size(MAX_DISK_QUOTA_REJECT_ENTRIES, sizeof(GlobalRejectMapEntry)));
+	pg_atomic_sub_fetch_u32(diskquota_shmem_size,
+	                        hash_estimate_size(MAX_DISK_QUOTA_REJECT_ENTRIES, sizeof(GlobalRejectMapEntry)));
 #endif
 
 	init_shm_worker_active_tables();
@@ -496,10 +496,11 @@ disk_quota_shmem_startup(void)
 	                               diskquota_max_monitored_databases, &hash_ctl, HASH_ELEM, DISKQUOTA_OID_HASH);
 
 #ifdef USE_ASSERT_CHECKING
-	pg_atomic_sub_fetch_u32(diskquota_shmem_size, hash_estimate_size(diskquota_max_monitored_databases, sizeof(MonitorDBEntry)));
+	pg_atomic_sub_fetch_u32(diskquota_shmem_size,
+	                        hash_estimate_size(diskquota_max_monitored_databases, sizeof(struct MonitorDBEntryStruct)));
 #endif
 
-	init_launcher_shmem();
+	if (IS_QUERY_DISPATCHER()) init_launcher_shmem();
 	LWLockRelease(AddinShmemInitLock);
 
 #ifdef USE_ASSERT_CHECKING
@@ -548,10 +549,10 @@ static Size
 diskquota_worker_shmem_size()
 {
 	Size size;
-	size = hash_estimate_size(MAX_NUM_TABLE_SIZE_ENTRIES / diskquota_max_monitored_databases + 100,
-	                          sizeof(TableSizeEntry));
-	size = add_size(size, hash_estimate_size(diskquota_max_local_reject_entries, sizeof(LocalRejectMapEntry)));
-	size = add_size(size, hash_estimate_size(MAX_QUOTA_MAP_ENTRIES, sizeof(QuotaInfoEntry)));
+	size = hash_estimate_size(MAX_NUM_TABLE_SIZE_ENTRIES, sizeof(TableSizeEntry)); // table_size_map
+	size = add_size(size, hash_estimate_size(diskquota_max_local_reject_entries,
+	                                         sizeof(LocalRejectMapEntry))); // local_disk_quota_reject_map
+	size = add_size(size, hash_estimate_size(MAX_QUOTA_MAP_ENTRIES, sizeof(QuotaInfoEntry))); // quota_info_map
 	size = add_size(size, sizeof(TimestampTz)); // table_size_map_last_overflow_report
 	size = add_size(size, sizeof(TimestampTz)); // local_disk_quota_reject_map_last_overflow_report
 	size = add_size(size, sizeof(TimestampTz)); // quota_info_map_last_overflow_report
@@ -566,23 +567,27 @@ static Size
 DiskQuotaShmemSize(void)
 {
 	Size size;
-	size = sizeof(ExtensionDDLMessage);
+	size = sizeof(ExtensionDDLMessage); // extension_ddl_message
 
 #ifdef USE_ASSERT_CHECKING
-	size = add_size(size, sizeof(pg_atomic_uint32));
+	size = add_size(size, sizeof(pg_atomic_uint32)); // diskquota_shmem_size
 #endif
 
-	size = add_size(size, hash_estimate_size(MAX_DISK_QUOTA_REJECT_ENTRIES, sizeof(GlobalRejectMapEntry)));
-	size = add_size(size, hash_estimate_size(diskquota_max_active_tables, sizeof(DiskQuotaActiveTableEntry)));
-	size = add_size(size, hash_estimate_size(diskquota_max_active_tables, sizeof(DiskQuotaRelationCacheEntry)));
-	size = add_size(size, hash_estimate_size(diskquota_max_active_tables, sizeof(DiskQuotaRelidCacheEntry)));
-	size = add_size(size, hash_estimate_size(diskquota_max_active_tables, sizeof(Oid)));
+	size = add_size(size, hash_estimate_size(MAX_DISK_QUOTA_REJECT_ENTRIES,
+	                                         sizeof(GlobalRejectMapEntry))); // disk_quota_reject_map
+	size = add_size(size, hash_estimate_size(diskquota_max_active_tables,
+	                                         sizeof(DiskQuotaActiveTableFileEntry))); // active_tables_map
+	size = add_size(size, hash_estimate_size(diskquota_max_active_tables,
+	                                         sizeof(DiskQuotaRelationCacheEntry))); // relation_cache
+	size = add_size(size,
+	                hash_estimate_size(diskquota_max_active_tables, sizeof(DiskQuotaRelidCacheEntry))); // relid_cache
+	size = add_size(size, hash_estimate_size(diskquota_max_active_tables, sizeof(Oid))); // altered_reloid_cache
 	size = add_size(size, hash_estimate_size(diskquota_max_monitored_databases,
 	                                         sizeof(struct MonitorDBEntryStruct))); // monitored_dbid_cache
 
 	if (IS_QUERY_DISPATCHER())
 	{
-		size = add_size(size, diskquota_launcher_shmem_size());
+		size = add_size(size, diskquota_launcher_shmem_size()); // DiskquotaLauncherShmem
 		size = add_size(size, diskquota_worker_shmem_size() * diskquota_max_monitored_databases);
 	}
 
@@ -615,7 +620,8 @@ init_disk_quota_model(uint32 id)
 	                                            &hash_ctl, HASH_ELEM, DISKQUOTA_TAG_HASH);
 
 #ifdef USE_ASSERT_CHECKING
-	pg_atomic_sub_fetch_u32(diskquota_shmem_size, hash_estimate_size(MAX_NUM_TABLE_SIZE_ENTRIES, sizeof(TableSizeEntry)));
+	pg_atomic_sub_fetch_u32(diskquota_shmem_size,
+	                        hash_estimate_size(MAX_NUM_TABLE_SIZE_ENTRIES, sizeof(TableSizeEntry)));
 #endif
 
 	format_name("TableSizeEntrymap_last_overflow_report", id, &str);
@@ -638,7 +644,8 @@ init_disk_quota_model(uint32 id)
 	                               &hash_ctl, HASH_ELEM, DISKQUOTA_TAG_HASH);
 
 #ifdef USE_ASSERT_CHECKING
-	pg_atomic_sub_fetch_u32(diskquota_shmem_size, hash_estimate_size(diskquota_max_local_reject_entries, sizeof(LocalRejectMapEntry)));
+	pg_atomic_sub_fetch_u32(diskquota_shmem_size,
+	                        hash_estimate_size(diskquota_max_local_reject_entries, sizeof(LocalRejectMapEntry)));
 #endif
 
 	format_name("localrejectmap_last_overflow_report", id, &str);

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -460,24 +460,14 @@ disk_quota_shmem_startup(void)
 	 * to store out-of-quota rejectmap. active_tables_map is used to store
 	 * active tables whose disk usage is changed.
 	 */
-	extension_ddl_message = ShmemInitStruct("disk_quota_extension_ddl_message", sizeof(ExtensionDDLMessage), &found);
+	extension_ddl_message = DiskquotaShmemInitStruct("disk_quota_extension_ddl_message", sizeof(ExtensionDDLMessage), &found);
 	if (!found) memset((void *)extension_ddl_message, 0, sizeof(ExtensionDDLMessage));
-
-#ifdef USE_ASSERT_CHECKING
-	if (!found) pg_atomic_sub_fetch_u64(diskquota_shmem_size, sizeof(ExtensionDDLMessage));
-#endif
-
 	memset(&hash_ctl, 0, sizeof(hash_ctl));
 	hash_ctl.keysize   = sizeof(RejectMapEntry);
 	hash_ctl.entrysize = sizeof(GlobalRejectMapEntry);
 	disk_quota_reject_map =
 	        DiskquotaShmemInitHash("rejectmap whose quota limitation is reached", diskquota_max_local_reject_entries,
 	                               MAX_DISK_QUOTA_REJECT_ENTRIES, &hash_ctl, HASH_ELEM, DISKQUOTA_TAG_HASH);
-
-#ifdef USE_ASSERT_CHECKING
-	pg_atomic_sub_fetch_u64(diskquota_shmem_size,
-	                        hash_estimate_size(MAX_DISK_QUOTA_REJECT_ENTRIES, sizeof(GlobalRejectMapEntry)));
-#endif
 
 	init_shm_worker_active_tables();
 
@@ -490,11 +480,6 @@ disk_quota_shmem_startup(void)
 	monitored_dbid_cache =
 	        DiskquotaShmemInitHash("table oid cache which shoud tracking", diskquota_max_monitored_databases,
 	                               diskquota_max_monitored_databases, &hash_ctl, HASH_ELEM, DISKQUOTA_OID_HASH);
-
-#ifdef USE_ASSERT_CHECKING
-	pg_atomic_sub_fetch_u64(diskquota_shmem_size,
-	                        hash_estimate_size(diskquota_max_monitored_databases, sizeof(struct MonitorDBEntryStruct)));
-#endif
 
 	if (IS_QUERY_DISPATCHER()) init_launcher_shmem();
 	LWLockRelease(AddinShmemInitLock);
@@ -617,18 +602,9 @@ init_disk_quota_model(uint32 id)
 	table_size_map     = DiskquotaShmemInitHash(str.data, INIT_NUM_TABLE_SIZE_ENTRIES, MAX_NUM_TABLE_SIZE_ENTRIES,
 	                                            &hash_ctl, HASH_ELEM, DISKQUOTA_TAG_HASH);
 
-#ifdef USE_ASSERT_CHECKING
-	pg_atomic_sub_fetch_u64(diskquota_shmem_size,
-	                        hash_estimate_size(MAX_NUM_TABLE_SIZE_ENTRIES, sizeof(TableSizeEntry)));
-#endif
-
 	format_name("TableSizeEntrymap_last_overflow_report", id, &str);
-	table_size_map_last_overflow_report = ShmemInitStruct(str.data, sizeof(TimestampTz), &found);
+	table_size_map_last_overflow_report = DiskquotaShmemInitStruct(str.data, sizeof(TimestampTz), &found);
 	if (!found) *table_size_map_last_overflow_report = 0;
-
-#ifdef USE_ASSERT_CHECKING
-	if (!found) pg_atomic_sub_fetch_u64(diskquota_shmem_size, sizeof(TimestampTz));
-#endif
 
 	/* for localrejectmap */
 	/* WARNNING: The max length of name of the map is 48 */
@@ -640,18 +616,9 @@ init_disk_quota_model(uint32 id)
 	        DiskquotaShmemInitHash(str.data, diskquota_max_local_reject_entries, diskquota_max_local_reject_entries,
 	                               &hash_ctl, HASH_ELEM, DISKQUOTA_TAG_HASH);
 
-#ifdef USE_ASSERT_CHECKING
-	pg_atomic_sub_fetch_u64(diskquota_shmem_size,
-	                        hash_estimate_size(diskquota_max_local_reject_entries, sizeof(LocalRejectMapEntry)));
-#endif
-
 	format_name("localrejectmap_last_overflow_report", id, &str);
-	local_disk_quota_reject_map_last_overflow_report = ShmemInitStruct(str.data, sizeof(TimestampTz), &found);
+	local_disk_quota_reject_map_last_overflow_report = DiskquotaShmemInitStruct(str.data, sizeof(TimestampTz), &found);
 	if (!found) *local_disk_quota_reject_map_last_overflow_report = 0;
-
-#ifdef USE_ASSERT_CHECKING
-	if (!found) pg_atomic_sub_fetch_u64(diskquota_shmem_size, sizeof(TimestampTz));
-#endif
 
 	/* for quota_info_map */
 	format_name("QuotaInfoMap", id, &str);
@@ -661,17 +628,9 @@ init_disk_quota_model(uint32 id)
 	quota_info_map     = DiskquotaShmemInitHash(str.data, INIT_QUOTA_MAP_ENTRIES, MAX_QUOTA_MAP_ENTRIES, &hash_ctl,
 	                                            HASH_ELEM, DISKQUOTA_TAG_HASH);
 
-#ifdef USE_ASSERT_CHECKING
-	pg_atomic_sub_fetch_u64(diskquota_shmem_size, hash_estimate_size(MAX_QUOTA_MAP_ENTRIES, sizeof(QuotaInfoEntry)));
-#endif
-
 	format_name("QuotaInfoMap_last_overflow_report", id, &str);
-	quota_info_map_last_overflow_report = ShmemInitStruct(str.data, sizeof(TimestampTz), &found);
+	quota_info_map_last_overflow_report = DiskquotaShmemInitStruct(str.data, sizeof(TimestampTz), &found);
 	if (!found) *quota_info_map_last_overflow_report = 0;
-
-#ifdef USE_ASSERT_CHECKING
-	if (!found) pg_atomic_sub_fetch_u64(diskquota_shmem_size, sizeof(TimestampTz));
-#endif
 
 	pfree(str.data);
 

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -211,7 +211,7 @@ static const char *local_disk_quota_reject_map_warning =
 static shmem_startup_hook_type prev_shmem_startup_hook = NULL;
 
 #ifdef USE_ASSERT_CHECKING
-pg_atomic_uint32 *diskquota_shmem_size;
+pg_atomic_uint64 *diskquota_shmem_size;
 #endif
 
 /* functions to maintain the quota maps */
@@ -448,8 +448,8 @@ disk_quota_shmem_startup(void)
 	LWLockAcquire(AddinShmemInitLock, LW_EXCLUSIVE);
 
 #ifdef USE_ASSERT_CHECKING
-	diskquota_shmem_size = ShmemInitStruct("diskquota_shmem_size", sizeof(pg_atomic_uint32), &found);
-	if (!found) pg_atomic_init_u32(diskquota_shmem_size, DiskQuotaShmemSize() - sizeof(pg_atomic_uint32));
+	diskquota_shmem_size = ShmemInitStruct("diskquota_shmem_size", sizeof(pg_atomic_uint64), &found);
+	if (!found) pg_atomic_init_u64(diskquota_shmem_size, DiskQuotaShmemSize() - sizeof(pg_atomic_uint64));
 #endif
 
 	init_lwlocks();
@@ -464,7 +464,7 @@ disk_quota_shmem_startup(void)
 	if (!found) memset((void *)extension_ddl_message, 0, sizeof(ExtensionDDLMessage));
 
 #ifdef USE_ASSERT_CHECKING
-	if (!found) pg_atomic_sub_fetch_u32(diskquota_shmem_size, sizeof(ExtensionDDLMessage));
+	if (!found) pg_atomic_sub_fetch_u64(diskquota_shmem_size, sizeof(ExtensionDDLMessage));
 #endif
 
 	memset(&hash_ctl, 0, sizeof(hash_ctl));
@@ -475,7 +475,7 @@ disk_quota_shmem_startup(void)
 	                               MAX_DISK_QUOTA_REJECT_ENTRIES, &hash_ctl, HASH_ELEM, DISKQUOTA_TAG_HASH);
 
 #ifdef USE_ASSERT_CHECKING
-	pg_atomic_sub_fetch_u32(diskquota_shmem_size,
+	pg_atomic_sub_fetch_u64(diskquota_shmem_size,
 	                        hash_estimate_size(MAX_DISK_QUOTA_REJECT_ENTRIES, sizeof(GlobalRejectMapEntry)));
 #endif
 
@@ -492,7 +492,7 @@ disk_quota_shmem_startup(void)
 	                               diskquota_max_monitored_databases, &hash_ctl, HASH_ELEM, DISKQUOTA_OID_HASH);
 
 #ifdef USE_ASSERT_CHECKING
-	pg_atomic_sub_fetch_u32(diskquota_shmem_size,
+	pg_atomic_sub_fetch_u64(diskquota_shmem_size,
 	                        hash_estimate_size(diskquota_max_monitored_databases, sizeof(struct MonitorDBEntryStruct)));
 #endif
 
@@ -501,10 +501,10 @@ disk_quota_shmem_startup(void)
 
 #ifdef USE_ASSERT_CHECKING
 	if (IS_QUERY_DISPATCHER())
-		Assert(pg_atomic_read_u32(diskquota_shmem_size) ==
+		Assert(pg_atomic_read_u64(diskquota_shmem_size) ==
 		       diskquota_worker_shmem_size() * diskquota_max_monitored_databases);
 	else
-		Assert(pg_atomic_read_u32(diskquota_shmem_size) == 0);
+		Assert(pg_atomic_read_u64(diskquota_shmem_size) == 0);
 #endif
 }
 
@@ -570,7 +570,7 @@ DiskQuotaShmemSize(void)
 	size = sizeof(ExtensionDDLMessage); // extension_ddl_message
 
 #ifdef USE_ASSERT_CHECKING
-	size = add_size(size, sizeof(pg_atomic_uint32)); // diskquota_shmem_size
+	size = add_size(size, sizeof(pg_atomic_uint64)); // diskquota_shmem_size
 #endif
 
 	size = add_size(size, hash_estimate_size(MAX_DISK_QUOTA_REJECT_ENTRIES,
@@ -607,7 +607,7 @@ init_disk_quota_model(uint32 id)
 	initStringInfo(&str);
 
 #ifdef USE_ASSERT_CHECKING
-	Assert(pg_atomic_read_u32(diskquota_shmem_size) >= 0);
+	Assert(pg_atomic_read_u64(diskquota_shmem_size) >= 0);
 #endif
 
 	format_name("TableSizeEntrymap", id, &str);
@@ -618,7 +618,7 @@ init_disk_quota_model(uint32 id)
 	                                            &hash_ctl, HASH_ELEM, DISKQUOTA_TAG_HASH);
 
 #ifdef USE_ASSERT_CHECKING
-	pg_atomic_sub_fetch_u32(diskquota_shmem_size,
+	pg_atomic_sub_fetch_u64(diskquota_shmem_size,
 	                        hash_estimate_size(MAX_NUM_TABLE_SIZE_ENTRIES, sizeof(TableSizeEntry)));
 #endif
 
@@ -627,7 +627,7 @@ init_disk_quota_model(uint32 id)
 	if (!found) *table_size_map_last_overflow_report = 0;
 
 #ifdef USE_ASSERT_CHECKING
-	if (!found) pg_atomic_sub_fetch_u32(diskquota_shmem_size, sizeof(TimestampTz));
+	if (!found) pg_atomic_sub_fetch_u64(diskquota_shmem_size, sizeof(TimestampTz));
 #endif
 
 	/* for localrejectmap */
@@ -641,7 +641,7 @@ init_disk_quota_model(uint32 id)
 	                               &hash_ctl, HASH_ELEM, DISKQUOTA_TAG_HASH);
 
 #ifdef USE_ASSERT_CHECKING
-	pg_atomic_sub_fetch_u32(diskquota_shmem_size,
+	pg_atomic_sub_fetch_u64(diskquota_shmem_size,
 	                        hash_estimate_size(diskquota_max_local_reject_entries, sizeof(LocalRejectMapEntry)));
 #endif
 
@@ -650,7 +650,7 @@ init_disk_quota_model(uint32 id)
 	if (!found) *local_disk_quota_reject_map_last_overflow_report = 0;
 
 #ifdef USE_ASSERT_CHECKING
-	if (!found) pg_atomic_sub_fetch_u32(diskquota_shmem_size, sizeof(TimestampTz));
+	if (!found) pg_atomic_sub_fetch_u64(diskquota_shmem_size, sizeof(TimestampTz));
 #endif
 
 	/* for quota_info_map */
@@ -662,7 +662,7 @@ init_disk_quota_model(uint32 id)
 	                                            HASH_ELEM, DISKQUOTA_TAG_HASH);
 
 #ifdef USE_ASSERT_CHECKING
-	pg_atomic_sub_fetch_u32(diskquota_shmem_size, hash_estimate_size(MAX_QUOTA_MAP_ENTRIES, sizeof(QuotaInfoEntry)));
+	pg_atomic_sub_fetch_u64(diskquota_shmem_size, hash_estimate_size(MAX_QUOTA_MAP_ENTRIES, sizeof(QuotaInfoEntry)));
 #endif
 
 	format_name("QuotaInfoMap_last_overflow_report", id, &str);
@@ -670,13 +670,13 @@ init_disk_quota_model(uint32 id)
 	if (!found) *quota_info_map_last_overflow_report = 0;
 
 #ifdef USE_ASSERT_CHECKING
-	if (!found) pg_atomic_sub_fetch_u32(diskquota_shmem_size, sizeof(TimestampTz));
+	if (!found) pg_atomic_sub_fetch_u64(diskquota_shmem_size, sizeof(TimestampTz));
 #endif
 
 	pfree(str.data);
 
 #ifdef USE_ASSERT_CHECKING
-	Assert(pg_atomic_read_u32(diskquota_shmem_size) >= 0);
+	Assert(pg_atomic_read_u64(diskquota_shmem_size) >= 0);
 #endif
 }
 

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -210,10 +210,9 @@ static const char *local_disk_quota_reject_map_warning =
 
 static shmem_startup_hook_type prev_shmem_startup_hook = NULL;
 
-extern DiskquotaLauncherShmemStruct *DiskquotaLauncherShmem;
-
 #ifdef USE_ASSERT_CHECKING
-pg_atomic_uint64 *diskquota_shmem_size;
+extern DiskquotaLauncherShmemStruct *DiskquotaLauncherShmem;
+pg_atomic_uint64                    *diskquota_shmem_size;
 #endif
 
 /* functions to maintain the quota maps */

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -243,6 +243,8 @@ static bool get_table_size_entry_flag(TableSizeEntry *entry, TableSizeEntryFlag 
 static void reset_table_size_entry_flag(TableSizeEntry *entry, TableSizeEntryFlag flag);
 static void set_table_size_entry_flag(TableSizeEntry *entry, TableSizeEntryFlag flag);
 
+static Size diskquota_worker_shmem_size();
+
 typedef struct
 {
 	ArrayBuildState *tableids;
@@ -451,7 +453,7 @@ disk_quota_shmem_startup(void)
 
 #ifdef USE_ASSERT_CHECKING
 	diskquota_shmem_size = ShmemInitStruct("diskquota_shmem_size", sizeof(pg_atomic_uint32), &found);
-	if (!found) pg_atomic_init_u32(diskquota_shmem_size, DiskQuotaShmemSize());
+	if (!found) pg_atomic_init_u32(diskquota_shmem_size, DiskQuotaShmemSize() - sizeof(pg_atomic_uint32));
 	if (found) elog(WARNING, "diskquota_shmem_size found!");
 #endif
 
@@ -505,6 +507,11 @@ disk_quota_shmem_startup(void)
 
 #ifdef USE_ASSERT_CHECKING
 	elog(WARNING, "diskquota_shmem_size = %i", pg_atomic_read_u32(diskquota_shmem_size));
+	if (IS_QUERY_DISPATCHER())
+		Assert(pg_atomic_read_u32(diskquota_shmem_size) ==
+		       diskquota_worker_shmem_size() * diskquota_max_monitored_databases);
+	else
+		Assert(pg_atomic_read_u32(diskquota_shmem_size) == 0);
 #endif
 }
 
@@ -608,6 +615,7 @@ init_disk_quota_model(uint32 id)
 
 #ifdef USE_ASSERT_CHECKING
 	elog(WARNING, "diskquota_shmem_size = %i", pg_atomic_read_u32(diskquota_shmem_size));
+	Assert(pg_atomic_read_u32(diskquota_shmem_size) >= 0);
 #endif
 
 	LWLockAcquire(AddinShmemInitLock, LW_EXCLUSIVE);
@@ -684,6 +692,7 @@ init_disk_quota_model(uint32 id)
 
 #ifdef USE_ASSERT_CHECKING
 	elog(WARNING, "diskquota_shmem_size = %i", pg_atomic_read_u32(diskquota_shmem_size));
+	Assert(pg_atomic_read_u32(diskquota_shmem_size) >= 0);
 #endif
 }
 

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -574,8 +574,7 @@ DiskQuotaShmemSize(void)
 	size = add_size(size, hash_estimate_size(MAX_DISK_QUOTA_REJECT_ENTRIES, DISK_QUOTA_REJECT_MAP_ENTRY_SIZE));
 	size = add_size(size, hash_estimate_size(diskquota_max_active_tables, ACTIVE_TABLES_MAP_ENTRY_SIZE));
 	size = add_size(size, hash_estimate_size(diskquota_max_active_tables, RELATION_CACHE_ENTRY_SIZE));
-	size = add_size(size,
-	                hash_estimate_size(diskquota_max_active_tables, sizeof(DiskQuotaRelidCacheEntry))); // relid_cache
+	size = add_size(size, hash_estimate_size(diskquota_max_active_tables, RELID_CACHE_ENTRY_SIZE));
 	size = add_size(size, hash_estimate_size(diskquota_max_active_tables, sizeof(Oid))); // altered_reloid_cache
 	size = add_size(size, hash_estimate_size(diskquota_max_monitored_databases,
 	                                         sizeof(struct MonitorDBEntryStruct))); // monitored_dbid_cache

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -612,6 +612,16 @@ init_disk_quota_model(uint32 id)
 	table_size_map_last_overflow_report = ShmemInitStruct(str.data, sizeof(TimestampTz), &found);
 	if (!found) *table_size_map_last_overflow_report = 0;
 
+#ifdef USE_ASSERT_CHECKING
+	if (!found)
+	{
+		pg_atomic_sub_fetch_u64(diskquota_shmem_size, sizeof(TimestampTz)); // table_size_map_last_overflow_report
+		pg_atomic_sub_fetch_u64(diskquota_shmem_size,
+		                        sizeof(TimestampTz)); // local_disk_quota_reject_map_last_overflow_report
+		pg_atomic_sub_fetch_u64(diskquota_shmem_size, sizeof(TimestampTz)); // quota_info_map_last_overflow_report
+	}
+#endif
+
 	/* for localrejectmap */
 	/* WARNNING: The max length of name of the map is 48 */
 	format_name("localrejectmap", id, &str);

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -460,7 +460,8 @@ disk_quota_shmem_startup(void)
 	 * to store out-of-quota rejectmap. active_tables_map is used to store
 	 * active tables whose disk usage is changed.
 	 */
-	extension_ddl_message = DiskquotaShmemInitStruct("disk_quota_extension_ddl_message", sizeof(ExtensionDDLMessage), &found);
+	extension_ddl_message =
+	        DiskquotaShmemInitStruct("disk_quota_extension_ddl_message", sizeof(ExtensionDDLMessage), &found);
 	if (!found) memset((void *)extension_ddl_message, 0, sizeof(ExtensionDDLMessage));
 	memset(&hash_ctl, 0, sizeof(hash_ctl));
 	hash_ctl.keysize   = sizeof(RejectMapEntry);

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -219,8 +219,9 @@ static const char *local_disk_quota_reject_map_warning =
 static shmem_startup_hook_type prev_shmem_startup_hook = NULL;
 
 #ifdef USE_ASSERT_CHECKING
-pg_atomic_uint64 *diskquota_shmem_size;
-void              diskquota_shmem_size_sub(Size size);
+extern DiskquotaLauncherShmemStruct *DiskquotaLauncherShmem;
+pg_atomic_uint64                    *diskquota_shmem_size;
+void                                 diskquota_shmem_size_sub(Size size);
 #endif
 
 /* functions to maintain the quota maps */
@@ -613,7 +614,8 @@ init_disk_quota_model(uint32 id)
 	if (!found) *table_size_map_last_overflow_report = 0;
 
 #ifdef USE_ASSERT_CHECKING
-	if (!found) diskquota_shmem_size_sub(TABLE_SIZE_MAP_LAST_OVERFLOW_REPORT_SIZE);
+	if (!DiskquotaLauncherShmem || !DiskquotaLauncherShmem->isDynamicWorker)
+		diskquota_shmem_size_sub(TABLE_SIZE_MAP_LAST_OVERFLOW_REPORT_SIZE);
 #endif
 
 	/* for localrejectmap */
@@ -632,7 +634,8 @@ init_disk_quota_model(uint32 id)
 	if (!found) *local_disk_quota_reject_map_last_overflow_report = 0;
 
 #ifdef USE_ASSERT_CHECKING
-	if (!found) diskquota_shmem_size_sub(LOCAL_DISK_QUOTA_REJECT_MAP_LAST_OVERFLOW_REPORT_SIZE);
+	if (!DiskquotaLauncherShmem || !DiskquotaLauncherShmem->isDynamicWorker)
+		diskquota_shmem_size_sub(LOCAL_DISK_QUOTA_REJECT_MAP_LAST_OVERFLOW_REPORT_SIZE);
 #endif
 
 	/* for quota_info_map */
@@ -647,7 +650,8 @@ init_disk_quota_model(uint32 id)
 	if (!found) *quota_info_map_last_overflow_report = 0;
 
 #ifdef USE_ASSERT_CHECKING
-	if (!found) diskquota_shmem_size_sub(QUOTA_INFO_MAP_LAST_OVERFLOW_REPORT_SIZE);
+	if (!DiskquotaLauncherShmem || !DiskquotaLauncherShmem->isDynamicWorker)
+		diskquota_shmem_size_sub(QUOTA_INFO_MAP_LAST_OVERFLOW_REPORT_SIZE);
 #endif
 
 	pfree(str.data);
@@ -694,6 +698,12 @@ vacuum_disk_quota_model(uint32 id)
 	format_name("TableSizeEntrymap_last_overflow_report", id, &str);
 	table_size_map_last_overflow_report = ShmemInitStruct(str.data, TABLE_SIZE_MAP_LAST_OVERFLOW_REPORT_SIZE, &found);
 	if (!found) *table_size_map_last_overflow_report = 0;
+
+#ifdef USE_ASSERT_CHECKING
+	if (!DiskquotaLauncherShmem || !DiskquotaLauncherShmem->isDynamicWorker)
+		diskquota_shmem_size_sub(TABLE_SIZE_MAP_LAST_OVERFLOW_REPORT_SIZE);
+#endif
+
 	/* localrejectmap */
 	format_name("localrejectmap", id, &str);
 	memset(&hash_ctl, 0, sizeof(hash_ctl));
@@ -712,6 +722,11 @@ vacuum_disk_quota_model(uint32 id)
 	        ShmemInitStruct(str.data, LOCAL_DISK_QUOTA_REJECT_MAP_LAST_OVERFLOW_REPORT_SIZE, &found);
 	if (!found) *local_disk_quota_reject_map_last_overflow_report = 0;
 
+#ifdef USE_ASSERT_CHECKING
+	if (!DiskquotaLauncherShmem || !DiskquotaLauncherShmem->isDynamicWorker)
+		diskquota_shmem_size_sub(LOCAL_DISK_QUOTA_REJECT_MAP_LAST_OVERFLOW_REPORT_SIZE);
+#endif
+
 	/* quota_info_map */
 	format_name("QuotaInfoMap", id, &str);
 	memset(&hash_ctl, 0, sizeof(hash_ctl));
@@ -727,6 +742,11 @@ vacuum_disk_quota_model(uint32 id)
 	format_name("QuotaInfoMap_last_overflow_report", id, &str);
 	quota_info_map_last_overflow_report = ShmemInitStruct(str.data, QUOTA_INFO_MAP_LAST_OVERFLOW_REPORT_SIZE, &found);
 	if (!found) *quota_info_map_last_overflow_report = 0;
+
+#ifdef USE_ASSERT_CHECKING
+	if (!DiskquotaLauncherShmem || !DiskquotaLauncherShmem->isDynamicWorker)
+		diskquota_shmem_size_sub(QUOTA_INFO_MAP_LAST_OVERFLOW_REPORT_SIZE);
+#endif
 
 	pfree(str.data);
 }

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -449,7 +449,15 @@ disk_quota_shmem_startup(void)
 
 #ifdef USE_ASSERT_CHECKING
 	diskquota_shmem_size = ShmemInitStruct("diskquota_shmem_size", sizeof(pg_atomic_uint64), &found);
-	if (!found) pg_atomic_init_u64(diskquota_shmem_size, DiskQuotaShmemSize() - sizeof(pg_atomic_uint64));
+	if (!found)
+	{
+		pg_atomic_init_u64(diskquota_shmem_size, DiskQuotaShmemSize());
+		pg_atomic_sub_fetch_u64(diskquota_shmem_size, sizeof(pg_atomic_uint64));    // diskquota_shmem_size
+		pg_atomic_sub_fetch_u64(diskquota_shmem_size, sizeof(ExtensionDDLMessage)); // extension_ddl_message
+
+		if (IS_QUERY_DISPATCHER())
+			pg_atomic_sub_fetch_u64(diskquota_shmem_size, diskquota_launcher_shmem_size()); // DiskquotaLauncherShmem
+	}
 #endif
 
 	init_lwlocks();
@@ -460,8 +468,7 @@ disk_quota_shmem_startup(void)
 	 * to store out-of-quota rejectmap. active_tables_map is used to store
 	 * active tables whose disk usage is changed.
 	 */
-	extension_ddl_message =
-	        DiskquotaShmemInitStruct("disk_quota_extension_ddl_message", sizeof(ExtensionDDLMessage), &found);
+	extension_ddl_message = ShmemInitStruct("disk_quota_extension_ddl_message", sizeof(ExtensionDDLMessage), &found);
 	if (!found) memset((void *)extension_ddl_message, 0, sizeof(ExtensionDDLMessage));
 	memset(&hash_ctl, 0, sizeof(hash_ctl));
 	hash_ctl.keysize   = sizeof(RejectMapEntry);
@@ -604,7 +611,7 @@ init_disk_quota_model(uint32 id)
 	                                            &hash_ctl, HASH_ELEM, DISKQUOTA_TAG_HASH);
 
 	format_name("TableSizeEntrymap_last_overflow_report", id, &str);
-	table_size_map_last_overflow_report = DiskquotaShmemInitStruct(str.data, sizeof(TimestampTz), &found);
+	table_size_map_last_overflow_report = ShmemInitStruct(str.data, sizeof(TimestampTz), &found);
 	if (!found) *table_size_map_last_overflow_report = 0;
 
 	/* for localrejectmap */
@@ -618,7 +625,7 @@ init_disk_quota_model(uint32 id)
 	                               &hash_ctl, HASH_ELEM, DISKQUOTA_TAG_HASH);
 
 	format_name("localrejectmap_last_overflow_report", id, &str);
-	local_disk_quota_reject_map_last_overflow_report = DiskquotaShmemInitStruct(str.data, sizeof(TimestampTz), &found);
+	local_disk_quota_reject_map_last_overflow_report = ShmemInitStruct(str.data, sizeof(TimestampTz), &found);
 	if (!found) *local_disk_quota_reject_map_last_overflow_report = 0;
 
 	/* for quota_info_map */
@@ -630,7 +637,7 @@ init_disk_quota_model(uint32 id)
 	                                            HASH_ELEM, DISKQUOTA_TAG_HASH);
 
 	format_name("QuotaInfoMap_last_overflow_report", id, &str);
-	quota_info_map_last_overflow_report = DiskquotaShmemInitStruct(str.data, sizeof(TimestampTz), &found);
+	quota_info_map_last_overflow_report = ShmemInitStruct(str.data, sizeof(TimestampTz), &found);
 	if (!found) *quota_info_map_last_overflow_report = 0;
 
 	pfree(str.data);

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -472,6 +472,7 @@ disk_quota_shmem_startup(void)
 	 */
 	extension_ddl_message = ShmemInitStruct("disk_quota_extension_ddl_message", sizeof(ExtensionDDLMessage), &found);
 	if (!found) memset((void *)extension_ddl_message, 0, sizeof(ExtensionDDLMessage));
+
 	memset(&hash_ctl, 0, sizeof(hash_ctl));
 	hash_ctl.keysize   = sizeof(RejectMapEntry);
 	hash_ctl.entrysize = sizeof(GlobalRejectMapEntry);

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -575,7 +575,7 @@ DiskQuotaShmemSize(void)
 	size = add_size(size, hash_estimate_size(diskquota_max_active_tables, ACTIVE_TABLES_MAP_ENTRY_SIZE));
 	size = add_size(size, hash_estimate_size(diskquota_max_active_tables, RELATION_CACHE_ENTRY_SIZE));
 	size = add_size(size, hash_estimate_size(diskquota_max_active_tables, RELID_CACHE_ENTRY_SIZE));
-	size = add_size(size, hash_estimate_size(diskquota_max_active_tables, sizeof(Oid))); // altered_reloid_cache
+	size = add_size(size, hash_estimate_size(diskquota_max_active_tables, ALTERED_RELOID_CACHE_ENTRY_SIZE));
 	size = add_size(size, hash_estimate_size(diskquota_max_monitored_databases,
 	                                         sizeof(struct MonitorDBEntryStruct))); // monitored_dbid_cache
 

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -211,8 +211,7 @@ static const char *local_disk_quota_reject_map_warning =
 static shmem_startup_hook_type prev_shmem_startup_hook = NULL;
 
 #ifdef USE_ASSERT_CHECKING
-extern DiskquotaLauncherShmemStruct *DiskquotaLauncherShmem;
-pg_atomic_uint64                    *diskquota_shmem_size;
+pg_atomic_uint64 *diskquota_shmem_size;
 #endif
 
 /* functions to maintain the quota maps */
@@ -453,11 +452,17 @@ disk_quota_shmem_startup(void)
 	if (!found)
 	{
 		pg_atomic_init_u64(diskquota_shmem_size, DiskQuotaShmemSize());
-		pg_atomic_sub_fetch_u64(diskquota_shmem_size, sizeof(pg_atomic_uint64));    // diskquota_shmem_size
+		Assert(pg_atomic_read_u64(diskquota_shmem_size) >= sizeof(pg_atomic_uint64));
+		pg_atomic_sub_fetch_u64(diskquota_shmem_size, sizeof(pg_atomic_uint64)); // diskquota_shmem_size
+		Assert(pg_atomic_read_u64(diskquota_shmem_size) >= sizeof(ExtensionDDLMessage));
 		pg_atomic_sub_fetch_u64(diskquota_shmem_size, sizeof(ExtensionDDLMessage)); // extension_ddl_message
 
 		if (IS_QUERY_DISPATCHER())
-			pg_atomic_sub_fetch_u64(diskquota_shmem_size, diskquota_launcher_shmem_size()); // DiskquotaLauncherShmem
+		{
+			Size size = diskquota_launcher_shmem_size();
+			Assert(pg_atomic_read_u64(diskquota_shmem_size) >= size);
+			pg_atomic_sub_fetch_u64(diskquota_shmem_size, size); // DiskquotaLauncherShmem
+		}
 	}
 #endif
 
@@ -600,12 +605,6 @@ init_disk_quota_model(uint32 id)
 	bool           found;
 	initStringInfo(&str);
 
-#ifdef USE_ASSERT_CHECKING
-	Assert(DiskquotaLauncherShmem);
-
-	if (!DiskquotaLauncherShmem->isDynamicWorker) Assert(pg_atomic_read_u64(diskquota_shmem_size) >= 0);
-#endif
-
 	format_name("TableSizeEntrymap", id, &str);
 	memset(&hash_ctl, 0, sizeof(hash_ctl));
 	hash_ctl.keysize   = sizeof(TableSizeEntryKey);
@@ -619,9 +618,12 @@ init_disk_quota_model(uint32 id)
 #ifdef USE_ASSERT_CHECKING
 	if (!found)
 	{
+		Assert(pg_atomic_read_u64(diskquota_shmem_size) >= sizeof(TimestampTz));
 		pg_atomic_sub_fetch_u64(diskquota_shmem_size, sizeof(TimestampTz)); // table_size_map_last_overflow_report
+		Assert(pg_atomic_read_u64(diskquota_shmem_size) >= sizeof(TimestampTz));
 		pg_atomic_sub_fetch_u64(diskquota_shmem_size,
 		                        sizeof(TimestampTz)); // local_disk_quota_reject_map_last_overflow_report
+		Assert(pg_atomic_read_u64(diskquota_shmem_size) >= sizeof(TimestampTz));
 		pg_atomic_sub_fetch_u64(diskquota_shmem_size, sizeof(TimestampTz)); // quota_info_map_last_overflow_report
 	}
 #endif
@@ -652,10 +654,6 @@ init_disk_quota_model(uint32 id)
 	if (!found) *quota_info_map_last_overflow_report = 0;
 
 	pfree(str.data);
-
-#ifdef USE_ASSERT_CHECKING
-	if (!DiskquotaLauncherShmem->isDynamicWorker) Assert(pg_atomic_read_u64(diskquota_shmem_size) >= 0);
-#endif
 }
 
 /*

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -489,7 +489,7 @@ disk_quota_shmem_startup(void)
 
 	memset(&hash_ctl, 0, sizeof(hash_ctl));
 	hash_ctl.keysize   = sizeof(Oid);
-	hash_ctl.entrysize = sizeof(struct MonitorDBEntryStruct);
+	hash_ctl.entrysize = MONITORED_DBID_CACHE_ENTRY_SIZE;
 
 	monitored_dbid_cache =
 	        DiskquotaShmemInitHash("table oid cache which shoud tracking", diskquota_max_monitored_databases,
@@ -576,8 +576,7 @@ DiskQuotaShmemSize(void)
 	size = add_size(size, hash_estimate_size(diskquota_max_active_tables, RELATION_CACHE_ENTRY_SIZE));
 	size = add_size(size, hash_estimate_size(diskquota_max_active_tables, RELID_CACHE_ENTRY_SIZE));
 	size = add_size(size, hash_estimate_size(diskquota_max_active_tables, ALTERED_RELOID_CACHE_ENTRY_SIZE));
-	size = add_size(size, hash_estimate_size(diskquota_max_monitored_databases,
-	                                         sizeof(struct MonitorDBEntryStruct))); // monitored_dbid_cache
+	size = add_size(size, hash_estimate_size(diskquota_max_monitored_databases, MONITORED_DBID_CACHE_ENTRY_SIZE));
 
 	if (IS_QUERY_DISPATCHER())
 	{

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -212,6 +212,7 @@ static shmem_startup_hook_type prev_shmem_startup_hook = NULL;
 
 #ifdef USE_ASSERT_CHECKING
 pg_atomic_uint64 *diskquota_shmem_size;
+void              diskquota_shmem_size_sub(Size size);
 #endif
 
 /* functions to maintain the quota maps */
@@ -452,17 +453,10 @@ disk_quota_shmem_startup(void)
 	if (!found)
 	{
 		pg_atomic_init_u64(diskquota_shmem_size, DiskQuotaShmemSize());
-		Assert(pg_atomic_read_u64(diskquota_shmem_size) >= sizeof(pg_atomic_uint64));
-		pg_atomic_sub_fetch_u64(diskquota_shmem_size, sizeof(pg_atomic_uint64)); // diskquota_shmem_size
-		Assert(pg_atomic_read_u64(diskquota_shmem_size) >= sizeof(ExtensionDDLMessage));
-		pg_atomic_sub_fetch_u64(diskquota_shmem_size, sizeof(ExtensionDDLMessage)); // extension_ddl_message
+		diskquota_shmem_size_sub(sizeof(pg_atomic_uint64));    // diskquota_shmem_size
+		diskquota_shmem_size_sub(sizeof(ExtensionDDLMessage)); // extension_ddl_message
 
-		if (IS_QUERY_DISPATCHER())
-		{
-			Size size = diskquota_launcher_shmem_size();
-			Assert(pg_atomic_read_u64(diskquota_shmem_size) >= size);
-			pg_atomic_sub_fetch_u64(diskquota_shmem_size, size); // DiskquotaLauncherShmem
-		}
+		if (IS_QUERY_DISPATCHER()) diskquota_shmem_size_sub(diskquota_launcher_shmem_size()); // DiskquotaLauncherShmem
 	}
 #endif
 
@@ -618,13 +612,9 @@ init_disk_quota_model(uint32 id)
 #ifdef USE_ASSERT_CHECKING
 	if (!found)
 	{
-		Assert(pg_atomic_read_u64(diskquota_shmem_size) >= sizeof(TimestampTz));
-		pg_atomic_sub_fetch_u64(diskquota_shmem_size, sizeof(TimestampTz)); // table_size_map_last_overflow_report
-		Assert(pg_atomic_read_u64(diskquota_shmem_size) >= sizeof(TimestampTz));
-		pg_atomic_sub_fetch_u64(diskquota_shmem_size,
-		                        sizeof(TimestampTz)); // local_disk_quota_reject_map_last_overflow_report
-		Assert(pg_atomic_read_u64(diskquota_shmem_size) >= sizeof(TimestampTz));
-		pg_atomic_sub_fetch_u64(diskquota_shmem_size, sizeof(TimestampTz)); // quota_info_map_last_overflow_report
+		diskquota_shmem_size_sub(sizeof(TimestampTz)); // table_size_map_last_overflow_report
+		diskquota_shmem_size_sub(sizeof(TimestampTz)); // local_disk_quota_reject_map_last_overflow_report
+		diskquota_shmem_size_sub(sizeof(TimestampTz)); // quota_info_map_last_overflow_report
 	}
 #endif
 
@@ -2416,3 +2406,12 @@ set_table_size_entry_flag(TableSizeEntry *entry, TableSizeEntryFlag flag)
 {
 	entry->flag |= flag;
 }
+
+#ifdef USE_ASSERT_CHECKING
+void
+diskquota_shmem_size_sub(Size size)
+{
+	Assert(pg_atomic_read_u64(diskquota_shmem_size) >= size);
+	pg_atomic_sub_fetch_u64(diskquota_shmem_size, size);
+}
+#endif

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -457,8 +457,8 @@ disk_quota_shmem_startup(void)
 	if (!found)
 	{
 		pg_atomic_init_u64(diskquota_shmem_size, DiskQuotaShmemSize());
-		diskquota_shmem_size_sub(sizeof(pg_atomic_uint64));    // diskquota_shmem_size
-		diskquota_shmem_size_sub(sizeof(ExtensionDDLMessage)); // extension_ddl_message
+		diskquota_shmem_size_sub(sizeof(pg_atomic_uint64)); // diskquota_shmem_size
+		diskquota_shmem_size_sub(EXTENSION_DDL_MESSAGE_SIZE);
 
 		if (IS_QUERY_DISPATCHER()) diskquota_shmem_size_sub(diskquota_launcher_shmem_size()); // DiskquotaLauncherShmem
 	}
@@ -472,8 +472,8 @@ disk_quota_shmem_startup(void)
 	 * to store out-of-quota rejectmap. active_tables_map is used to store
 	 * active tables whose disk usage is changed.
 	 */
-	extension_ddl_message = ShmemInitStruct("disk_quota_extension_ddl_message", sizeof(ExtensionDDLMessage), &found);
-	if (!found) memset((void *)extension_ddl_message, 0, sizeof(ExtensionDDLMessage));
+	extension_ddl_message = ShmemInitStruct("disk_quota_extension_ddl_message", EXTENSION_DDL_MESSAGE_SIZE, &found);
+	if (!found) memset((void *)extension_ddl_message, 0, EXTENSION_DDL_MESSAGE_SIZE);
 
 	memset(&hash_ctl, 0, sizeof(hash_ctl));
 	hash_ctl.keysize   = sizeof(RejectMapEntry);
@@ -564,7 +564,7 @@ static Size
 DiskQuotaShmemSize(void)
 {
 	Size size;
-	size = sizeof(ExtensionDDLMessage); // extension_ddl_message
+	size = EXTENSION_DDL_MESSAGE_SIZE;
 
 #ifdef USE_ASSERT_CHECKING
 	size = add_size(size, sizeof(pg_atomic_uint64)); // diskquota_shmem_size

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -572,8 +572,7 @@ DiskQuotaShmemSize(void)
 #endif
 
 	size = add_size(size, hash_estimate_size(MAX_DISK_QUOTA_REJECT_ENTRIES, DISK_QUOTA_REJECT_MAP_ENTRY_SIZE));
-	size = add_size(size, hash_estimate_size(diskquota_max_active_tables,
-	                                         sizeof(DiskQuotaActiveTableFileEntry))); // active_tables_map
+	size = add_size(size, hash_estimate_size(diskquota_max_active_tables, ACTIVE_TABLES_MAP_ENTRY_SIZE));
 	size = add_size(size, hash_estimate_size(diskquota_max_active_tables,
 	                                         sizeof(DiskQuotaRelationCacheEntry))); // relation_cache
 	size = add_size(size,

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -610,12 +610,7 @@ init_disk_quota_model(uint32 id)
 	if (!found) *table_size_map_last_overflow_report = 0;
 
 #ifdef USE_ASSERT_CHECKING
-	if (!found)
-	{
-		diskquota_shmem_size_sub(sizeof(TimestampTz)); // table_size_map_last_overflow_report
-		diskquota_shmem_size_sub(sizeof(TimestampTz)); // local_disk_quota_reject_map_last_overflow_report
-		diskquota_shmem_size_sub(sizeof(TimestampTz)); // quota_info_map_last_overflow_report
-	}
+	if (!found) diskquota_shmem_size_sub(sizeof(TimestampTz)); // table_size_map_last_overflow_report
 #endif
 
 	/* for localrejectmap */
@@ -632,6 +627,10 @@ init_disk_quota_model(uint32 id)
 	local_disk_quota_reject_map_last_overflow_report = ShmemInitStruct(str.data, sizeof(TimestampTz), &found);
 	if (!found) *local_disk_quota_reject_map_last_overflow_report = 0;
 
+#ifdef USE_ASSERT_CHECKING
+	if (!found) diskquota_shmem_size_sub(sizeof(TimestampTz)); // local_disk_quota_reject_map_last_overflow_report
+#endif
+
 	/* for quota_info_map */
 	format_name("QuotaInfoMap", id, &str);
 	memset(&hash_ctl, 0, sizeof(hash_ctl));
@@ -642,6 +641,10 @@ init_disk_quota_model(uint32 id)
 	format_name("QuotaInfoMap_last_overflow_report", id, &str);
 	quota_info_map_last_overflow_report = ShmemInitStruct(str.data, sizeof(TimestampTz), &found);
 	if (!found) *quota_info_map_last_overflow_report = 0;
+
+#ifdef USE_ASSERT_CHECKING
+	if (!found) diskquota_shmem_size_sub(sizeof(TimestampTz)); // quota_info_map_last_overflow_report
+#endif
 
 	pfree(str.data);
 }

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -77,6 +77,7 @@
 #define DISK_QUOTA_REJECT_MAP_ENTRY_SIZE sizeof(GlobalRejectMapEntry)
 #define TABLE_SIZE_MAP_ENTRY_SIZE sizeof(TableSizeEntry)
 #define LOCAL_DISK_QUOTA_REJECT_MAP_ENTRY_SIZE sizeof(LocalRejectMapEntry)
+#define QUOTA_INFO_MAP_ENTRY_SIZE sizeof(QuotaInfoEntry)
 
 typedef struct TableSizeEntry       TableSizeEntry;
 typedef struct NamespaceSizeEntry   NamespaceSizeEntry;
@@ -552,7 +553,7 @@ diskquota_worker_shmem_size(void)
 	size = hash_estimate_size(MAX_NUM_TABLE_SIZE_ENTRIES, TABLE_SIZE_MAP_ENTRY_SIZE);
 	size = add_size(size,
 	                hash_estimate_size(diskquota_max_local_reject_entries, LOCAL_DISK_QUOTA_REJECT_MAP_ENTRY_SIZE));
-	size = add_size(size, hash_estimate_size(MAX_QUOTA_MAP_ENTRIES, sizeof(QuotaInfoEntry))); // quota_info_map
+	size = add_size(size, hash_estimate_size(MAX_QUOTA_MAP_ENTRIES, QUOTA_INFO_MAP_ENTRY_SIZE));
 	size = add_size(size, TABLE_SIZE_MAP_LAST_OVERFLOW_REPORT_SIZE);
 	size = add_size(size, LOCAL_DISK_QUOTA_REJECT_MAP_LAST_OVERFLOW_REPORT_SIZE);
 	size = add_size(size, QUOTA_INFO_MAP_LAST_OVERFLOW_REPORT_SIZE);
@@ -637,7 +638,7 @@ init_disk_quota_model(uint32 id)
 	/* for quota_info_map */
 	format_name("QuotaInfoMap", id, &str);
 	memset(&hash_ctl, 0, sizeof(hash_ctl));
-	hash_ctl.entrysize = sizeof(QuotaInfoEntry);
+	hash_ctl.entrysize = QUOTA_INFO_MAP_ENTRY_SIZE;
 	hash_ctl.keysize   = sizeof(QuotaInfoEntryKey);
 	quota_info_map     = DiskquotaShmemInitHash(str.data, INIT_QUOTA_MAP_ENTRIES, MAX_QUOTA_MAP_ENTRIES, &hash_ctl,
 	                                            HASH_ELEM, DISKQUOTA_TAG_HASH);
@@ -714,7 +715,7 @@ vacuum_disk_quota_model(uint32 id)
 	/* quota_info_map */
 	format_name("QuotaInfoMap", id, &str);
 	memset(&hash_ctl, 0, sizeof(hash_ctl));
-	hash_ctl.entrysize = sizeof(QuotaInfoEntry);
+	hash_ctl.entrysize = QUOTA_INFO_MAP_ENTRY_SIZE;
 	hash_ctl.keysize   = sizeof(QuotaInfoEntryKey);
 	quota_info_map     = DiskquotaShmemInitHash(str.data, INIT_QUOTA_MAP_ENTRIES, MAX_QUOTA_MAP_ENTRIES, &hash_ctl,
 	                                            HASH_ELEM, DISKQUOTA_TAG_HASH);

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -445,16 +445,11 @@ disk_quota_shmem_startup(void)
 
 	if (prev_shmem_startup_hook) (*prev_shmem_startup_hook)();
 
-#ifdef USE_ASSERT_CHECKING
-	elog(WARNING, "diskquota_shmem_size = %li", DiskQuotaShmemSize());
-#endif
-
 	LWLockAcquire(AddinShmemInitLock, LW_EXCLUSIVE);
 
 #ifdef USE_ASSERT_CHECKING
 	diskquota_shmem_size = ShmemInitStruct("diskquota_shmem_size", sizeof(pg_atomic_uint32), &found);
 	if (!found) pg_atomic_init_u32(diskquota_shmem_size, DiskQuotaShmemSize() - sizeof(pg_atomic_uint32));
-	if (found) elog(WARNING, "diskquota_shmem_size found!");
 #endif
 
 	init_lwlocks();
@@ -470,7 +465,6 @@ disk_quota_shmem_startup(void)
 
 #ifdef USE_ASSERT_CHECKING
 	if (!found) pg_atomic_sub_fetch_u32(diskquota_shmem_size, sizeof(ExtensionDDLMessage));
-	if (found) elog(WARNING, "extension_ddl_message found!");
 #endif
 
 	memset(&hash_ctl, 0, sizeof(hash_ctl));
@@ -506,7 +500,6 @@ disk_quota_shmem_startup(void)
 	LWLockRelease(AddinShmemInitLock);
 
 #ifdef USE_ASSERT_CHECKING
-	elog(WARNING, "diskquota_shmem_size = %i", pg_atomic_read_u32(diskquota_shmem_size));
 	if (IS_QUERY_DISPATCHER())
 		Assert(pg_atomic_read_u32(diskquota_shmem_size) ==
 		       diskquota_worker_shmem_size() * diskquota_max_monitored_databases);
@@ -614,7 +607,6 @@ init_disk_quota_model(uint32 id)
 	initStringInfo(&str);
 
 #ifdef USE_ASSERT_CHECKING
-	elog(WARNING, "diskquota_shmem_size = %i", pg_atomic_read_u32(diskquota_shmem_size));
 	Assert(pg_atomic_read_u32(diskquota_shmem_size) >= 0);
 #endif
 
@@ -638,7 +630,6 @@ init_disk_quota_model(uint32 id)
 
 #ifdef USE_ASSERT_CHECKING
 	if (!found) pg_atomic_sub_fetch_u32(diskquota_shmem_size, sizeof(TimestampTz));
-	if (found) elog(WARNING, "table_size_map_last_overflow_report found!");
 #endif
 
 	/* for localrejectmap */
@@ -662,7 +653,6 @@ init_disk_quota_model(uint32 id)
 
 #ifdef USE_ASSERT_CHECKING
 	if (!found) pg_atomic_sub_fetch_u32(diskquota_shmem_size, sizeof(TimestampTz));
-	if (found) elog(WARNING, "local_disk_quota_reject_map_last_overflow_report found!");
 #endif
 
 	/* for quota_info_map */
@@ -683,7 +673,6 @@ init_disk_quota_model(uint32 id)
 
 #ifdef USE_ASSERT_CHECKING
 	if (!found) pg_atomic_sub_fetch_u32(diskquota_shmem_size, sizeof(TimestampTz));
-	if (found) elog(WARNING, "quota_info_map_last_overflow_report found!");
 #endif
 
 	pfree(str.data);
@@ -691,7 +680,6 @@ init_disk_quota_model(uint32 id)
 	LWLockRelease(AddinShmemInitLock);
 
 #ifdef USE_ASSERT_CHECKING
-	elog(WARNING, "diskquota_shmem_size = %i", pg_atomic_read_u32(diskquota_shmem_size));
 	Assert(pg_atomic_read_u32(diskquota_shmem_size) >= 0);
 #endif
 }

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -219,11 +219,8 @@ static const char *local_disk_quota_reject_map_warning =
 static shmem_startup_hook_type prev_shmem_startup_hook = NULL;
 
 #ifdef USE_ASSERT_CHECKING
-extern DiskquotaLauncherShmemStruct *DiskquotaLauncherShmem;
-pg_atomic_uint64                    *diskquota_shmem_size;
-void                                 diskquota_shmem_size_sub(Size size);
-#else
-#define diskquota_shmem_size_sub(size) ((void)true)
+static pg_atomic_uint64 *diskquota_shmem_size;
+void                     diskquota_shmem_size_sub(Size size);
 #endif
 
 /* functions to maintain the quota maps */
@@ -465,9 +462,6 @@ disk_quota_shmem_startup(void)
 	{
 		pg_atomic_init_u64(diskquota_shmem_size, DiskQuotaShmemSize());
 		diskquota_shmem_size_sub(sizeof(pg_atomic_uint64)); // diskquota_shmem_size
-		diskquota_shmem_size_sub(EXTENSION_DDL_MESSAGE_SIZE);
-
-		if (IS_QUERY_DISPATCHER()) diskquota_shmem_size_sub(diskquota_launcher_shmem_size()); // DiskquotaLauncherShmem
 	}
 #endif
 
@@ -479,7 +473,8 @@ disk_quota_shmem_startup(void)
 	 * to store out-of-quota rejectmap. active_tables_map is used to store
 	 * active tables whose disk usage is changed.
 	 */
-	extension_ddl_message = ShmemInitStruct("disk_quota_extension_ddl_message", EXTENSION_DDL_MESSAGE_SIZE, &found);
+	extension_ddl_message =
+	        DiskquotaShmemInitStruct("disk_quota_extension_ddl_message", EXTENSION_DDL_MESSAGE_SIZE, &found);
 	if (!found) memset((void *)extension_ddl_message, 0, EXTENSION_DDL_MESSAGE_SIZE);
 
 	memset(&hash_ctl, 0, sizeof(hash_ctl));
@@ -612,9 +607,9 @@ init_disk_quota_model(uint32 id)
 	table_size_map     = DiskquotaShmemInitHash(str.data, INIT_NUM_TABLE_SIZE_ENTRIES, MAX_NUM_TABLE_SIZE_ENTRIES,
 	                                            &hash_ctl, HASH_ELEM, DISKQUOTA_TAG_HASH);
 	format_name("TableSizeEntrymap_last_overflow_report", id, &str);
-	table_size_map_last_overflow_report = ShmemInitStruct(str.data, TABLE_SIZE_MAP_LAST_OVERFLOW_REPORT_SIZE, &found);
+	table_size_map_last_overflow_report =
+	        DiskquotaShmemInitStruct(str.data, TABLE_SIZE_MAP_LAST_OVERFLOW_REPORT_SIZE, &found);
 	if (!found) *table_size_map_last_overflow_report = 0;
-	diskquota_shmem_size_sub(TABLE_SIZE_MAP_LAST_OVERFLOW_REPORT_SIZE);
 
 	/* for localrejectmap */
 	/* WARNNING: The max length of name of the map is 48 */
@@ -628,9 +623,8 @@ init_disk_quota_model(uint32 id)
 
 	format_name("localrejectmap_last_overflow_report", id, &str);
 	local_disk_quota_reject_map_last_overflow_report =
-	        ShmemInitStruct(str.data, LOCAL_DISK_QUOTA_REJECT_MAP_LAST_OVERFLOW_REPORT_SIZE, &found);
+	        DiskquotaShmemInitStruct(str.data, LOCAL_DISK_QUOTA_REJECT_MAP_LAST_OVERFLOW_REPORT_SIZE, &found);
 	if (!found) *local_disk_quota_reject_map_last_overflow_report = 0;
-	diskquota_shmem_size_sub(LOCAL_DISK_QUOTA_REJECT_MAP_LAST_OVERFLOW_REPORT_SIZE);
 
 	/* for quota_info_map */
 	format_name("QuotaInfoMap", id, &str);
@@ -640,9 +634,9 @@ init_disk_quota_model(uint32 id)
 	quota_info_map     = DiskquotaShmemInitHash(str.data, INIT_QUOTA_MAP_ENTRIES, MAX_QUOTA_MAP_ENTRIES, &hash_ctl,
 	                                            HASH_ELEM, DISKQUOTA_TAG_HASH);
 	format_name("QuotaInfoMap_last_overflow_report", id, &str);
-	quota_info_map_last_overflow_report = ShmemInitStruct(str.data, QUOTA_INFO_MAP_LAST_OVERFLOW_REPORT_SIZE, &found);
+	quota_info_map_last_overflow_report =
+	        DiskquotaShmemInitStruct(str.data, QUOTA_INFO_MAP_LAST_OVERFLOW_REPORT_SIZE, &found);
 	if (!found) *quota_info_map_last_overflow_report = 0;
-	diskquota_shmem_size_sub(QUOTA_INFO_MAP_LAST_OVERFLOW_REPORT_SIZE);
 
 	pfree(str.data);
 }
@@ -686,9 +680,9 @@ vacuum_disk_quota_model(uint32 id)
 	}
 
 	format_name("TableSizeEntrymap_last_overflow_report", id, &str);
-	table_size_map_last_overflow_report = ShmemInitStruct(str.data, TABLE_SIZE_MAP_LAST_OVERFLOW_REPORT_SIZE, &found);
+	table_size_map_last_overflow_report =
+	        DiskquotaShmemInitStruct(str.data, TABLE_SIZE_MAP_LAST_OVERFLOW_REPORT_SIZE, &found);
 	if (!found) *table_size_map_last_overflow_report = 0;
-	diskquota_shmem_size_sub(TABLE_SIZE_MAP_LAST_OVERFLOW_REPORT_SIZE);
 
 	/* localrejectmap */
 	format_name("localrejectmap", id, &str);
@@ -705,9 +699,8 @@ vacuum_disk_quota_model(uint32 id)
 	}
 	format_name("localrejectmap_last_overflow_report", id, &str);
 	local_disk_quota_reject_map_last_overflow_report =
-	        ShmemInitStruct(str.data, LOCAL_DISK_QUOTA_REJECT_MAP_LAST_OVERFLOW_REPORT_SIZE, &found);
+	        DiskquotaShmemInitStruct(str.data, LOCAL_DISK_QUOTA_REJECT_MAP_LAST_OVERFLOW_REPORT_SIZE, &found);
 	if (!found) *local_disk_quota_reject_map_last_overflow_report = 0;
-	diskquota_shmem_size_sub(LOCAL_DISK_QUOTA_REJECT_MAP_LAST_OVERFLOW_REPORT_SIZE);
 
 	/* quota_info_map */
 	format_name("QuotaInfoMap", id, &str);
@@ -722,9 +715,9 @@ vacuum_disk_quota_model(uint32 id)
 		hash_search(quota_info_map, &qentry->key, HASH_REMOVE, NULL);
 	}
 	format_name("QuotaInfoMap_last_overflow_report", id, &str);
-	quota_info_map_last_overflow_report = ShmemInitStruct(str.data, QUOTA_INFO_MAP_LAST_OVERFLOW_REPORT_SIZE, &found);
+	quota_info_map_last_overflow_report =
+	        DiskquotaShmemInitStruct(str.data, QUOTA_INFO_MAP_LAST_OVERFLOW_REPORT_SIZE, &found);
 	if (!found) *quota_info_map_last_overflow_report = 0;
-	diskquota_shmem_size_sub(QUOTA_INFO_MAP_LAST_OVERFLOW_REPORT_SIZE);
 
 	pfree(str.data);
 }
@@ -2419,7 +2412,6 @@ diskquota_shmem_size_sub(Size size)
 {
 	Assert(pg_atomic_read_u64(diskquota_shmem_size) >= size);
 
-	if (!DiskquotaLauncherShmem || !DiskquotaLauncherShmem->isDynamicWorker)
-		pg_atomic_sub_fetch_u64(diskquota_shmem_size, size);
+	pg_atomic_sub_fetch_u64(diskquota_shmem_size, size);
 }
 #endif

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -243,7 +243,7 @@ static bool get_table_size_entry_flag(TableSizeEntry *entry, TableSizeEntryFlag 
 static void reset_table_size_entry_flag(TableSizeEntry *entry, TableSizeEntryFlag flag);
 static void set_table_size_entry_flag(TableSizeEntry *entry, TableSizeEntryFlag flag);
 
-static Size diskquota_worker_shmem_size();
+static Size diskquota_worker_shmem_size(void);
 
 typedef struct
 {
@@ -546,7 +546,7 @@ init_lwlocks(void)
 }
 
 static Size
-diskquota_worker_shmem_size()
+diskquota_worker_shmem_size(void)
 {
 	Size size;
 	size = hash_estimate_size(MAX_NUM_TABLE_SIZE_ENTRIES, sizeof(TableSizeEntry)); // table_size_map

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -210,6 +210,10 @@ static const char *local_disk_quota_reject_map_warning =
 
 static shmem_startup_hook_type prev_shmem_startup_hook = NULL;
 
+#ifdef USE_ASSERT_CHECKING
+pg_atomic_uint32 *diskquota_shmem_size;
+#endif
+
 /* functions to maintain the quota maps */
 static void update_size_for_quota(int64 size, QuotaType type, Oid *keys, int16 segid);
 static void update_limit_for_quota(int64 limit, float segratio, QuotaType type, Oid *keys);
@@ -439,7 +443,18 @@ disk_quota_shmem_startup(void)
 
 	if (prev_shmem_startup_hook) (*prev_shmem_startup_hook)();
 
+#ifdef USE_ASSERT_CHECKING
+	elog(WARNING, "diskquota_shmem_size = %li", DiskQuotaShmemSize());
+#endif
+
 	LWLockAcquire(AddinShmemInitLock, LW_EXCLUSIVE);
+
+#ifdef USE_ASSERT_CHECKING
+	diskquota_shmem_size =
+	        ShmemInitStruct("diskquota_shmem_size", sizeof(pg_atomic_uint32), &found);
+	if (!found) pg_atomic_init_u32(diskquota_shmem_size, DiskQuotaShmemSize());
+	if (found) elog(WARNING, "diskquota_shmem_size found!");
+#endif
 
 	init_lwlocks();
 
@@ -452,12 +467,21 @@ disk_quota_shmem_startup(void)
 	extension_ddl_message = ShmemInitStruct("disk_quota_extension_ddl_message", sizeof(ExtensionDDLMessage), &found);
 	if (!found) memset((void *)extension_ddl_message, 0, sizeof(ExtensionDDLMessage));
 
+#ifdef USE_ASSERT_CHECKING
+	if (!found) pg_atomic_sub_fetch_u32(diskquota_shmem_size, sizeof(ExtensionDDLMessage));
+	if (found) elog(WARNING, "extension_ddl_message found!");
+#endif
+
 	memset(&hash_ctl, 0, sizeof(hash_ctl));
 	hash_ctl.keysize   = sizeof(RejectMapEntry);
 	hash_ctl.entrysize = sizeof(GlobalRejectMapEntry);
 	disk_quota_reject_map =
 	        DiskquotaShmemInitHash("rejectmap whose quota limitation is reached", diskquota_max_local_reject_entries,
 	                               MAX_DISK_QUOTA_REJECT_ENTRIES, &hash_ctl, HASH_ELEM, DISKQUOTA_TAG_HASH);
+
+#ifdef USE_ASSERT_CHECKING
+	pg_atomic_sub_fetch_u32(diskquota_shmem_size, hash_estimate_size(MAX_DISK_QUOTA_REJECT_ENTRIES, sizeof(GlobalRejectMapEntry)));
+#endif
 
 	init_shm_worker_active_tables();
 
@@ -470,8 +494,17 @@ disk_quota_shmem_startup(void)
 	monitored_dbid_cache =
 	        DiskquotaShmemInitHash("table oid cache which shoud tracking", diskquota_max_monitored_databases,
 	                               diskquota_max_monitored_databases, &hash_ctl, HASH_ELEM, DISKQUOTA_OID_HASH);
+
+#ifdef USE_ASSERT_CHECKING
+	pg_atomic_sub_fetch_u32(diskquota_shmem_size, hash_estimate_size(diskquota_max_monitored_databases, sizeof(MonitorDBEntry)));
+#endif
+
 	init_launcher_shmem();
 	LWLockRelease(AddinShmemInitLock);
+
+#ifdef USE_ASSERT_CHECKING
+	elog(WARNING, "diskquota_shmem_size = %i", pg_atomic_read_u32(diskquota_shmem_size));
+#endif
 }
 
 /*
@@ -534,6 +567,11 @@ DiskQuotaShmemSize(void)
 {
 	Size size;
 	size = sizeof(ExtensionDDLMessage);
+
+#ifdef USE_ASSERT_CHECKING
+	size = add_size(size, sizeof(pg_atomic_uint32));
+#endif
+
 	size = add_size(size, hash_estimate_size(MAX_DISK_QUOTA_REJECT_ENTRIES, sizeof(GlobalRejectMapEntry)));
 	size = add_size(size, hash_estimate_size(diskquota_max_active_tables, sizeof(DiskQuotaActiveTableEntry)));
 	size = add_size(size, hash_estimate_size(diskquota_max_active_tables, sizeof(DiskQuotaRelationCacheEntry)));
@@ -563,15 +601,31 @@ init_disk_quota_model(uint32 id)
 	bool           found;
 	initStringInfo(&str);
 
+#ifdef USE_ASSERT_CHECKING
+	elog(WARNING, "diskquota_shmem_size = %i", pg_atomic_read_u32(diskquota_shmem_size));
+#endif
+
+	LWLockAcquire(AddinShmemInitLock, LW_EXCLUSIVE);
+
 	format_name("TableSizeEntrymap", id, &str);
 	memset(&hash_ctl, 0, sizeof(hash_ctl));
 	hash_ctl.keysize   = sizeof(TableSizeEntryKey);
 	hash_ctl.entrysize = sizeof(TableSizeEntry);
 	table_size_map     = DiskquotaShmemInitHash(str.data, INIT_NUM_TABLE_SIZE_ENTRIES, MAX_NUM_TABLE_SIZE_ENTRIES,
 	                                            &hash_ctl, HASH_ELEM, DISKQUOTA_TAG_HASH);
+
+#ifdef USE_ASSERT_CHECKING
+	pg_atomic_sub_fetch_u32(diskquota_shmem_size, hash_estimate_size(MAX_NUM_TABLE_SIZE_ENTRIES, sizeof(TableSizeEntry)));
+#endif
+
 	format_name("TableSizeEntrymap_last_overflow_report", id, &str);
 	table_size_map_last_overflow_report = ShmemInitStruct(str.data, sizeof(TimestampTz), &found);
 	if (!found) *table_size_map_last_overflow_report = 0;
+
+#ifdef USE_ASSERT_CHECKING
+	if (!found) pg_atomic_sub_fetch_u32(diskquota_shmem_size, sizeof(TimestampTz));
+	if (found) elog(WARNING, "table_size_map_last_overflow_report found!");
+#endif
 
 	/* for localrejectmap */
 	/* WARNNING: The max length of name of the map is 48 */
@@ -583,9 +637,18 @@ init_disk_quota_model(uint32 id)
 	        DiskquotaShmemInitHash(str.data, diskquota_max_local_reject_entries, diskquota_max_local_reject_entries,
 	                               &hash_ctl, HASH_ELEM, DISKQUOTA_TAG_HASH);
 
+#ifdef USE_ASSERT_CHECKING
+	pg_atomic_sub_fetch_u32(diskquota_shmem_size, hash_estimate_size(diskquota_max_local_reject_entries, sizeof(LocalRejectMapEntry)));
+#endif
+
 	format_name("localrejectmap_last_overflow_report", id, &str);
 	local_disk_quota_reject_map_last_overflow_report = ShmemInitStruct(str.data, sizeof(TimestampTz), &found);
 	if (!found) *local_disk_quota_reject_map_last_overflow_report = 0;
+
+#ifdef USE_ASSERT_CHECKING
+	if (!found) pg_atomic_sub_fetch_u32(diskquota_shmem_size, sizeof(TimestampTz));
+	if (found) elog(WARNING, "local_disk_quota_reject_map_last_overflow_report found!");
+#endif
 
 	/* for quota_info_map */
 	format_name("QuotaInfoMap", id, &str);
@@ -594,11 +657,27 @@ init_disk_quota_model(uint32 id)
 	hash_ctl.keysize   = sizeof(QuotaInfoEntryKey);
 	quota_info_map     = DiskquotaShmemInitHash(str.data, INIT_QUOTA_MAP_ENTRIES, MAX_QUOTA_MAP_ENTRIES, &hash_ctl,
 	                                            HASH_ELEM, DISKQUOTA_TAG_HASH);
+
+#ifdef USE_ASSERT_CHECKING
+	pg_atomic_sub_fetch_u32(diskquota_shmem_size, hash_estimate_size(MAX_QUOTA_MAP_ENTRIES, sizeof(QuotaInfoEntry)));
+#endif
+
 	format_name("QuotaInfoMap_last_overflow_report", id, &str);
 	quota_info_map_last_overflow_report = ShmemInitStruct(str.data, sizeof(TimestampTz), &found);
 	if (!found) *quota_info_map_last_overflow_report = 0;
 
+#ifdef USE_ASSERT_CHECKING
+	if (!found) pg_atomic_sub_fetch_u32(diskquota_shmem_size, sizeof(TimestampTz));
+	if (found) elog(WARNING, "quota_info_map_last_overflow_report found!");
+#endif
+
 	pfree(str.data);
+
+	LWLockRelease(AddinShmemInitLock);
+
+#ifdef USE_ASSERT_CHECKING
+	elog(WARNING, "diskquota_shmem_size = %i", pg_atomic_read_u32(diskquota_shmem_size));
+#endif
 }
 
 /*

--- a/src/quotamodel.c
+++ b/src/quotamodel.c
@@ -71,6 +71,10 @@
 	         ? ((entry->key.id + 1) * SEGMENT_SIZE_ARRAY_LENGTH - 1)  \
 	         : SEGCOUNT)
 
+#define TABLE_SIZE_MAP_LAST_OVERFLOW_REPORT_SIZE sizeof(TimestampTz)
+#define LOCAL_DISK_QUOTA_REJECT_MAP_LAST_OVERFLOW_REPORT_SIZE sizeof(TimestampTz)
+#define QUOTA_INFO_MAP_LAST_OVERFLOW_REPORT_SIZE sizeof(TimestampTz)
+
 typedef struct TableSizeEntry       TableSizeEntry;
 typedef struct NamespaceSizeEntry   NamespaceSizeEntry;
 typedef struct RoleSizeEntry        RoleSizeEntry;
@@ -546,9 +550,9 @@ diskquota_worker_shmem_size(void)
 	size = add_size(size, hash_estimate_size(diskquota_max_local_reject_entries,
 	                                         sizeof(LocalRejectMapEntry))); // local_disk_quota_reject_map
 	size = add_size(size, hash_estimate_size(MAX_QUOTA_MAP_ENTRIES, sizeof(QuotaInfoEntry))); // quota_info_map
-	size = add_size(size, sizeof(TimestampTz)); // table_size_map_last_overflow_report
-	size = add_size(size, sizeof(TimestampTz)); // local_disk_quota_reject_map_last_overflow_report
-	size = add_size(size, sizeof(TimestampTz)); // quota_info_map_last_overflow_report
+	size = add_size(size, TABLE_SIZE_MAP_LAST_OVERFLOW_REPORT_SIZE);
+	size = add_size(size, LOCAL_DISK_QUOTA_REJECT_MAP_LAST_OVERFLOW_REPORT_SIZE);
+	size = add_size(size, QUOTA_INFO_MAP_LAST_OVERFLOW_REPORT_SIZE);
 	return size;
 }
 
@@ -606,11 +610,11 @@ init_disk_quota_model(uint32 id)
 	table_size_map     = DiskquotaShmemInitHash(str.data, INIT_NUM_TABLE_SIZE_ENTRIES, MAX_NUM_TABLE_SIZE_ENTRIES,
 	                                            &hash_ctl, HASH_ELEM, DISKQUOTA_TAG_HASH);
 	format_name("TableSizeEntrymap_last_overflow_report", id, &str);
-	table_size_map_last_overflow_report = ShmemInitStruct(str.data, sizeof(TimestampTz), &found);
+	table_size_map_last_overflow_report = ShmemInitStruct(str.data, TABLE_SIZE_MAP_LAST_OVERFLOW_REPORT_SIZE, &found);
 	if (!found) *table_size_map_last_overflow_report = 0;
 
 #ifdef USE_ASSERT_CHECKING
-	if (!found) diskquota_shmem_size_sub(sizeof(TimestampTz)); // table_size_map_last_overflow_report
+	if (!found) diskquota_shmem_size_sub(TABLE_SIZE_MAP_LAST_OVERFLOW_REPORT_SIZE);
 #endif
 
 	/* for localrejectmap */
@@ -624,11 +628,12 @@ init_disk_quota_model(uint32 id)
 	                               &hash_ctl, HASH_ELEM, DISKQUOTA_TAG_HASH);
 
 	format_name("localrejectmap_last_overflow_report", id, &str);
-	local_disk_quota_reject_map_last_overflow_report = ShmemInitStruct(str.data, sizeof(TimestampTz), &found);
+	local_disk_quota_reject_map_last_overflow_report =
+	        ShmemInitStruct(str.data, LOCAL_DISK_QUOTA_REJECT_MAP_LAST_OVERFLOW_REPORT_SIZE, &found);
 	if (!found) *local_disk_quota_reject_map_last_overflow_report = 0;
 
 #ifdef USE_ASSERT_CHECKING
-	if (!found) diskquota_shmem_size_sub(sizeof(TimestampTz)); // local_disk_quota_reject_map_last_overflow_report
+	if (!found) diskquota_shmem_size_sub(LOCAL_DISK_QUOTA_REJECT_MAP_LAST_OVERFLOW_REPORT_SIZE);
 #endif
 
 	/* for quota_info_map */
@@ -639,11 +644,11 @@ init_disk_quota_model(uint32 id)
 	quota_info_map     = DiskquotaShmemInitHash(str.data, INIT_QUOTA_MAP_ENTRIES, MAX_QUOTA_MAP_ENTRIES, &hash_ctl,
 	                                            HASH_ELEM, DISKQUOTA_TAG_HASH);
 	format_name("QuotaInfoMap_last_overflow_report", id, &str);
-	quota_info_map_last_overflow_report = ShmemInitStruct(str.data, sizeof(TimestampTz), &found);
+	quota_info_map_last_overflow_report = ShmemInitStruct(str.data, QUOTA_INFO_MAP_LAST_OVERFLOW_REPORT_SIZE, &found);
 	if (!found) *quota_info_map_last_overflow_report = 0;
 
 #ifdef USE_ASSERT_CHECKING
-	if (!found) diskquota_shmem_size_sub(sizeof(TimestampTz)); // quota_info_map_last_overflow_report
+	if (!found) diskquota_shmem_size_sub(QUOTA_INFO_MAP_LAST_OVERFLOW_REPORT_SIZE);
 #endif
 
 	pfree(str.data);
@@ -688,7 +693,7 @@ vacuum_disk_quota_model(uint32 id)
 	}
 
 	format_name("TableSizeEntrymap_last_overflow_report", id, &str);
-	table_size_map_last_overflow_report = ShmemInitStruct(str.data, sizeof(TimestampTz), &found);
+	table_size_map_last_overflow_report = ShmemInitStruct(str.data, TABLE_SIZE_MAP_LAST_OVERFLOW_REPORT_SIZE, &found);
 	if (!found) *table_size_map_last_overflow_report = 0;
 	/* localrejectmap */
 	format_name("localrejectmap", id, &str);
@@ -704,7 +709,8 @@ vacuum_disk_quota_model(uint32 id)
 		hash_search(local_disk_quota_reject_map, &localrejectentry->keyitem, HASH_REMOVE, NULL);
 	}
 	format_name("localrejectmap_last_overflow_report", id, &str);
-	local_disk_quota_reject_map_last_overflow_report = ShmemInitStruct(str.data, sizeof(TimestampTz), &found);
+	local_disk_quota_reject_map_last_overflow_report =
+	        ShmemInitStruct(str.data, LOCAL_DISK_QUOTA_REJECT_MAP_LAST_OVERFLOW_REPORT_SIZE, &found);
 	if (!found) *local_disk_quota_reject_map_last_overflow_report = 0;
 
 	/* quota_info_map */
@@ -720,7 +726,7 @@ vacuum_disk_quota_model(uint32 id)
 		hash_search(quota_info_map, &qentry->key, HASH_REMOVE, NULL);
 	}
 	format_name("QuotaInfoMap_last_overflow_report", id, &str);
-	quota_info_map_last_overflow_report = ShmemInitStruct(str.data, sizeof(TimestampTz), &found);
+	quota_info_map_last_overflow_report = ShmemInitStruct(str.data, QUOTA_INFO_MAP_LAST_OVERFLOW_REPORT_SIZE, &found);
 	if (!found) *quota_info_map_last_overflow_report = 0;
 
 	pfree(str.data);

--- a/src/relation_cache.c
+++ b/src/relation_cache.c
@@ -42,6 +42,10 @@ static const char *relid_cache_warning =
         "the number of relid cache entries reached the limit, please increase "
         "the GUC value for diskquota.max_active_tables.";
 
+#ifdef USE_ASSERT_CHECKING
+extern pg_atomic_uint32 *diskquota_shmem_size;
+#endif
+
 static void update_relation_entry(Oid relid, DiskQuotaRelationCacheEntry *relation_entry,
                                   DiskQuotaRelidCacheEntry *relid_entry);
 
@@ -58,11 +62,19 @@ init_shm_worker_relation_cache(void)
 	relation_cache = DiskquotaShmemInitHash("relation_cache", diskquota_max_active_tables, diskquota_max_active_tables,
 	                                        &ctl, HASH_ELEM, DISKQUOTA_OID_HASH);
 
+#ifdef USE_ASSERT_CHECKING
+	pg_atomic_sub_fetch_u32(diskquota_shmem_size, hash_estimate_size(diskquota_max_active_tables, sizeof(DiskQuotaRelationCacheEntry)));
+#endif
+
 	memset(&ctl, 0, sizeof(ctl));
 	ctl.keysize   = sizeof(Oid);
 	ctl.entrysize = sizeof(DiskQuotaRelidCacheEntry);
 	relid_cache = DiskquotaShmemInitHash("relid_cache", diskquota_max_active_tables, diskquota_max_active_tables, &ctl,
 	                                     HASH_ELEM, DISKQUOTA_OID_HASH);
+
+#ifdef USE_ASSERT_CHECKING
+	pg_atomic_sub_fetch_u32(diskquota_shmem_size, hash_estimate_size(diskquota_max_active_tables, sizeof(DiskQuotaRelidCacheEntry)));
+#endif
 }
 
 Oid

--- a/src/relation_cache.c
+++ b/src/relation_cache.c
@@ -43,7 +43,7 @@ static const char *relid_cache_warning =
         "the GUC value for diskquota.max_active_tables.";
 
 #ifdef USE_ASSERT_CHECKING
-extern pg_atomic_uint32 *diskquota_shmem_size;
+extern pg_atomic_uint64 *diskquota_shmem_size;
 #endif
 
 static void update_relation_entry(Oid relid, DiskQuotaRelationCacheEntry *relation_entry,
@@ -63,7 +63,7 @@ init_shm_worker_relation_cache(void)
 	                                        &ctl, HASH_ELEM, DISKQUOTA_OID_HASH);
 
 #ifdef USE_ASSERT_CHECKING
-	pg_atomic_sub_fetch_u32(diskquota_shmem_size,
+	pg_atomic_sub_fetch_u64(diskquota_shmem_size,
 	                        hash_estimate_size(diskquota_max_active_tables, sizeof(DiskQuotaRelationCacheEntry)));
 #endif
 
@@ -74,7 +74,7 @@ init_shm_worker_relation_cache(void)
 	                                     HASH_ELEM, DISKQUOTA_OID_HASH);
 
 #ifdef USE_ASSERT_CHECKING
-	pg_atomic_sub_fetch_u32(diskquota_shmem_size,
+	pg_atomic_sub_fetch_u64(diskquota_shmem_size,
 	                        hash_estimate_size(diskquota_max_active_tables, sizeof(DiskQuotaRelidCacheEntry)));
 #endif
 }

--- a/src/relation_cache.c
+++ b/src/relation_cache.c
@@ -63,7 +63,8 @@ init_shm_worker_relation_cache(void)
 	                                        &ctl, HASH_ELEM, DISKQUOTA_OID_HASH);
 
 #ifdef USE_ASSERT_CHECKING
-	pg_atomic_sub_fetch_u32(diskquota_shmem_size, hash_estimate_size(diskquota_max_active_tables, sizeof(DiskQuotaRelationCacheEntry)));
+	pg_atomic_sub_fetch_u32(diskquota_shmem_size,
+	                        hash_estimate_size(diskquota_max_active_tables, sizeof(DiskQuotaRelationCacheEntry)));
 #endif
 
 	memset(&ctl, 0, sizeof(ctl));
@@ -73,7 +74,8 @@ init_shm_worker_relation_cache(void)
 	                                     HASH_ELEM, DISKQUOTA_OID_HASH);
 
 #ifdef USE_ASSERT_CHECKING
-	pg_atomic_sub_fetch_u32(diskquota_shmem_size, hash_estimate_size(diskquota_max_active_tables, sizeof(DiskQuotaRelidCacheEntry)));
+	pg_atomic_sub_fetch_u32(diskquota_shmem_size,
+	                        hash_estimate_size(diskquota_max_active_tables, sizeof(DiskQuotaRelidCacheEntry)));
 #endif
 }
 

--- a/src/relation_cache.c
+++ b/src/relation_cache.c
@@ -42,10 +42,6 @@ static const char *relid_cache_warning =
         "the number of relid cache entries reached the limit, please increase "
         "the GUC value for diskquota.max_active_tables.";
 
-#ifdef USE_ASSERT_CHECKING
-extern pg_atomic_uint64 *diskquota_shmem_size;
-#endif
-
 static void update_relation_entry(Oid relid, DiskQuotaRelationCacheEntry *relation_entry,
                                   DiskQuotaRelidCacheEntry *relid_entry);
 
@@ -62,21 +58,11 @@ init_shm_worker_relation_cache(void)
 	relation_cache = DiskquotaShmemInitHash("relation_cache", diskquota_max_active_tables, diskquota_max_active_tables,
 	                                        &ctl, HASH_ELEM, DISKQUOTA_OID_HASH);
 
-#ifdef USE_ASSERT_CHECKING
-	pg_atomic_sub_fetch_u64(diskquota_shmem_size,
-	                        hash_estimate_size(diskquota_max_active_tables, sizeof(DiskQuotaRelationCacheEntry)));
-#endif
-
 	memset(&ctl, 0, sizeof(ctl));
 	ctl.keysize   = sizeof(Oid);
 	ctl.entrysize = sizeof(DiskQuotaRelidCacheEntry);
 	relid_cache = DiskquotaShmemInitHash("relid_cache", diskquota_max_active_tables, diskquota_max_active_tables, &ctl,
 	                                     HASH_ELEM, DISKQUOTA_OID_HASH);
-
-#ifdef USE_ASSERT_CHECKING
-	pg_atomic_sub_fetch_u64(diskquota_shmem_size,
-	                        hash_estimate_size(diskquota_max_active_tables, sizeof(DiskQuotaRelidCacheEntry)));
-#endif
 }
 
 Oid

--- a/src/relation_cache.c
+++ b/src/relation_cache.c
@@ -60,7 +60,7 @@ init_shm_worker_relation_cache(void)
 
 	memset(&ctl, 0, sizeof(ctl));
 	ctl.keysize   = sizeof(Oid);
-	ctl.entrysize = sizeof(DiskQuotaRelidCacheEntry);
+	ctl.entrysize = RELID_CACHE_ENTRY_SIZE;
 	relid_cache = DiskquotaShmemInitHash("relid_cache", diskquota_max_active_tables, diskquota_max_active_tables, &ctl,
 	                                     HASH_ELEM, DISKQUOTA_OID_HASH);
 }
@@ -208,7 +208,7 @@ update_relation_cache(Oid relid)
 		LWLockRelease(diskquota_locks.relation_cache_lock);
 		return;
 	}
-	memcpy(relid_entry, &relid_entry_data, sizeof(DiskQuotaRelidCacheEntry));
+	memcpy(relid_entry, &relid_entry_data, RELID_CACHE_ENTRY_SIZE);
 	LWLockRelease(diskquota_locks.relation_cache_lock);
 
 	prelid = get_primary_table_oid(relid, false);

--- a/src/relation_cache.c
+++ b/src/relation_cache.c
@@ -54,7 +54,7 @@ init_shm_worker_relation_cache(void)
 
 	memset(&ctl, 0, sizeof(ctl));
 	ctl.keysize    = sizeof(Oid);
-	ctl.entrysize  = sizeof(DiskQuotaRelationCacheEntry);
+	ctl.entrysize  = RELATION_CACHE_ENTRY_SIZE;
 	relation_cache = DiskquotaShmemInitHash("relation_cache", diskquota_max_active_tables, diskquota_max_active_tables,
 	                                        &ctl, HASH_ELEM, DISKQUOTA_OID_HASH);
 
@@ -198,7 +198,7 @@ update_relation_cache(Oid relid)
 		LWLockRelease(diskquota_locks.relation_cache_lock);
 		return;
 	}
-	memcpy(relation_entry, &relation_entry_data, sizeof(DiskQuotaRelationCacheEntry));
+	memcpy(relation_entry, &relation_entry_data, RELATION_CACHE_ENTRY_SIZE);
 
 	action      = check_hash_fullness(relid_cache, diskquota_max_active_tables, relid_cache_warning,
 	                                  &active_tables_map_last_overflow_report);
@@ -302,7 +302,7 @@ remove_committed_relation_from_cache(void)
 
 	memset(&ctl, 0, sizeof(ctl));
 	ctl.keysize   = sizeof(Oid);
-	ctl.entrysize = sizeof(DiskQuotaRelationCacheEntry);
+	ctl.entrysize = RELATION_CACHE_ENTRY_SIZE;
 	ctl.hcxt      = CurrentMemoryContext;
 	local_relation_cache =
 	        diskquota_hash_create("local relation cache", 1024, &ctl, HASH_ELEM | HASH_CONTEXT, DISKQUOTA_OID_HASH);
@@ -314,7 +314,7 @@ remove_committed_relation_from_cache(void)
 		/* The session of db1 should not see the table inside db2. */
 		if (entry->rnode.node.dbNode != MyDatabaseId) continue;
 		local_entry = hash_search(local_relation_cache, &entry->relid, HASH_ENTER, NULL);
-		memcpy(local_entry, entry, sizeof(DiskQuotaRelationCacheEntry));
+		memcpy(local_entry, entry, RELATION_CACHE_ENTRY_SIZE);
 	}
 	LWLockRelease(diskquota_locks.relation_cache_lock);
 
@@ -380,7 +380,7 @@ show_relation_cache(PG_FUNCTION_ARGS)
 		/* Create a local hash table and fill it with entries from shared memory. */
 		memset(&hashctl, 0, sizeof(hashctl));
 		hashctl.keysize   = sizeof(Oid);
-		hashctl.entrysize = sizeof(DiskQuotaRelationCacheEntry);
+		hashctl.entrysize = RELATION_CACHE_ENTRY_SIZE;
 		hashctl.hcxt      = CurrentMemoryContext;
 
 		relation_cache_ctx->relation_cache = diskquota_hash_create("relation_cache_ctx->relation_cache", 1024, &hashctl,
@@ -396,7 +396,7 @@ show_relation_cache(PG_FUNCTION_ARGS)
 			        hash_search(relation_cache_ctx->relation_cache, &entry->relid, HASH_ENTER_NULL, NULL);
 			if (local_entry)
 			{
-				memcpy(local_entry, entry, sizeof(DiskQuotaRelationCacheEntry));
+				memcpy(local_entry, entry, RELATION_CACHE_ENTRY_SIZE);
 			}
 		}
 		LWLockRelease(diskquota_locks.relation_cache_lock);
@@ -559,7 +559,7 @@ get_relation_entry(Oid relid, DiskQuotaRelationCacheEntry *entry)
 	tentry = hash_search(relation_cache, &relid, HASH_FIND, NULL);
 	if (tentry)
 	{
-		memcpy(entry, tentry, sizeof(DiskQuotaRelationCacheEntry));
+		memcpy(entry, tentry, RELATION_CACHE_ENTRY_SIZE);
 		LWLockRelease(diskquota_locks.relation_cache_lock);
 		return;
 	}


### PR DESCRIPTION
Fix shared memory allocation and usage in diskquota

When initializing the postmaster, the init_disk_quota_shmem function requested
shared memory from the PostgreSQL core (RequestAddinShmemSpace) with the size
calculated in the DiskQuotaShmemSize function. This function

1) added diskquota_launcher_shmem_size to the shared memory size only on the
coordinator, while the init_launcher_shmem function also over-initialized
diskquota_launcher_shmem_size on segments.

2) for the active_tables_map hashmap size, incorrectly used the size of the
DiskQuotaActiveTableEntry structure, instead of using the size of the
DiskQuotaActiveTableFileEntry structure.

3) for table_size_map incorrectly used (MAX_NUM_TABLE_SIZE_ENTRIES /
diskquota_max_monitored_databases + 100) * diskquota_max_monitored_databases
for the number of hashmap elements. However, in each worker, the
init_disk_quota_model function then allocates this hashmap for
MAX_NUM_TABLE_SIZE_ENTRIES elements.

This all needs to be fixed, and some checks should be added to ensure that the
shared memory size does not exceed the requested size. To avoid confusion about
which size is being requested for what purpose, additional defines have been
added.

Note: This patch changes the diskquota.max_table_segments GUC value from
cluster to per-database, which increases shared memory consumption. This only
fixes the current behavior before the patch and will be fixed in the next
patch.

Tests are not provided because it is quite difficult to exhaust shared memory
without exceeding the per-database limit.

Ticket: ADBDEV-8953